### PR TITLE
Vcdat2.0 sterling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 .ipynb_checkpoints
 frontend/
 .DS_Store
+
+build
+dist

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a development install:
 ```bash
 
     #Create the environment
-    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab
+    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab nb_conda_kernels
     source activate jupyter-vcdat
 
     # Go to vcs repo to update vcs code
@@ -45,7 +45,7 @@ jupyter lab build
 
 ## Possible issues:
 
+If you get an FFMPEG import error, run the following command:
 ```bash
-    #IF YOU GET FFMPEG IMPORT ERROR DO COMMAND:
     conda install -c conda-forge "ffmpeg>4"
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a development install:
 ```bash
 
     #Create the environment
-    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda jupyter-vcdat nodejs
+    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab
     source activate jupyter-vcdat
 
     # Go to vcs repo to update vcs code
@@ -27,10 +27,9 @@ For a development install:
     cd ..
     git clone https://github.com/CDAT/jupyter-vcdat.git
     cd jupyter-vcdat
-    git checkout [YOUR_DESIRED_BRANCH]
-    npm install
+    python setup.py install
     jupyter labextension install .
-
+    jupyter serverextension enable --py vcs_backend
 
     #To run, got to jupyter-vcdat repo
     jupyter lab

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a development install:
 ```bash
 
     #Create the environment
-    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab pip
+    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab pip nb_conda
     source activate jupyter-vcdat
 
     # Go to vcs repo to update vcs code

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a development install:
 ```bash
 
     #Create the environment
-    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab
+    conda create -n jupyter-vcdat -c cdat/label/nightly -c conda-forge -c cdat -c anaconda nodejs "python>3" vcs jupyterlab pip
     source activate jupyter-vcdat
 
     # Go to vcs repo to update vcs code

--- a/frontend/bin/npm
+++ b/frontend/bin/npm
@@ -1,1 +1,0 @@
-../lib/node_modules/npm/bin/npm-cli.js

--- a/frontend/bin/npx
+++ b/frontend/bin/npx
@@ -1,1 +1,0 @@
-../lib/node_modules/npm/bin/npx-cli.js

--- a/frontend/bin/tsc
+++ b/frontend/bin/tsc
@@ -1,1 +1,0 @@
-../lib/node_modules/typescript/bin/tsc

--- a/frontend/bin/tsserver
+++ b/frontend/bin/tsserver
@@ -1,1 +1,0 @@
-../lib/node_modules/typescript/bin/tsserver

--- a/frontend/share/man/man1/npm-README.1
+++ b/frontend/share/man/man1/npm-README.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-README.1

--- a/frontend/share/man/man1/npm-access.1
+++ b/frontend/share/man/man1/npm-access.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-access.1

--- a/frontend/share/man/man1/npm-adduser.1
+++ b/frontend/share/man/man1/npm-adduser.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-adduser.1

--- a/frontend/share/man/man1/npm-audit.1
+++ b/frontend/share/man/man1/npm-audit.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-audit.1

--- a/frontend/share/man/man1/npm-bin.1
+++ b/frontend/share/man/man1/npm-bin.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-bin.1

--- a/frontend/share/man/man1/npm-bugs.1
+++ b/frontend/share/man/man1/npm-bugs.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-bugs.1

--- a/frontend/share/man/man1/npm-build.1
+++ b/frontend/share/man/man1/npm-build.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-build.1

--- a/frontend/share/man/man1/npm-bundle.1
+++ b/frontend/share/man/man1/npm-bundle.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-bundle.1

--- a/frontend/share/man/man1/npm-cache.1
+++ b/frontend/share/man/man1/npm-cache.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-cache.1

--- a/frontend/share/man/man1/npm-ci.1
+++ b/frontend/share/man/man1/npm-ci.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-ci.1

--- a/frontend/share/man/man1/npm-completion.1
+++ b/frontend/share/man/man1/npm-completion.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-completion.1

--- a/frontend/share/man/man1/npm-config.1
+++ b/frontend/share/man/man1/npm-config.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-config.1

--- a/frontend/share/man/man1/npm-dedupe.1
+++ b/frontend/share/man/man1/npm-dedupe.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-dedupe.1

--- a/frontend/share/man/man1/npm-deprecate.1
+++ b/frontend/share/man/man1/npm-deprecate.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-deprecate.1

--- a/frontend/share/man/man1/npm-dist-tag.1
+++ b/frontend/share/man/man1/npm-dist-tag.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-dist-tag.1

--- a/frontend/share/man/man1/npm-docs.1
+++ b/frontend/share/man/man1/npm-docs.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-docs.1

--- a/frontend/share/man/man1/npm-doctor.1
+++ b/frontend/share/man/man1/npm-doctor.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-doctor.1

--- a/frontend/share/man/man1/npm-edit.1
+++ b/frontend/share/man/man1/npm-edit.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-edit.1

--- a/frontend/share/man/man1/npm-explore.1
+++ b/frontend/share/man/man1/npm-explore.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-explore.1

--- a/frontend/share/man/man1/npm-help-search.1
+++ b/frontend/share/man/man1/npm-help-search.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-help-search.1

--- a/frontend/share/man/man1/npm-help.1
+++ b/frontend/share/man/man1/npm-help.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-help.1

--- a/frontend/share/man/man1/npm-hook.1
+++ b/frontend/share/man/man1/npm-hook.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-hook.1

--- a/frontend/share/man/man1/npm-init.1
+++ b/frontend/share/man/man1/npm-init.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-init.1

--- a/frontend/share/man/man1/npm-install-ci-test.1
+++ b/frontend/share/man/man1/npm-install-ci-test.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-install-ci-test.1

--- a/frontend/share/man/man1/npm-install-test.1
+++ b/frontend/share/man/man1/npm-install-test.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-install-test.1

--- a/frontend/share/man/man1/npm-install.1
+++ b/frontend/share/man/man1/npm-install.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-install.1

--- a/frontend/share/man/man1/npm-link.1
+++ b/frontend/share/man/man1/npm-link.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-link.1

--- a/frontend/share/man/man1/npm-logout.1
+++ b/frontend/share/man/man1/npm-logout.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-logout.1

--- a/frontend/share/man/man1/npm-ls.1
+++ b/frontend/share/man/man1/npm-ls.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-ls.1

--- a/frontend/share/man/man1/npm-outdated.1
+++ b/frontend/share/man/man1/npm-outdated.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-outdated.1

--- a/frontend/share/man/man1/npm-owner.1
+++ b/frontend/share/man/man1/npm-owner.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-owner.1

--- a/frontend/share/man/man1/npm-pack.1
+++ b/frontend/share/man/man1/npm-pack.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-pack.1

--- a/frontend/share/man/man1/npm-ping.1
+++ b/frontend/share/man/man1/npm-ping.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-ping.1

--- a/frontend/share/man/man1/npm-prefix.1
+++ b/frontend/share/man/man1/npm-prefix.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-prefix.1

--- a/frontend/share/man/man1/npm-profile.1
+++ b/frontend/share/man/man1/npm-profile.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-profile.1

--- a/frontend/share/man/man1/npm-prune.1
+++ b/frontend/share/man/man1/npm-prune.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-prune.1

--- a/frontend/share/man/man1/npm-publish.1
+++ b/frontend/share/man/man1/npm-publish.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-publish.1

--- a/frontend/share/man/man1/npm-rebuild.1
+++ b/frontend/share/man/man1/npm-rebuild.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-rebuild.1

--- a/frontend/share/man/man1/npm-repo.1
+++ b/frontend/share/man/man1/npm-repo.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-repo.1

--- a/frontend/share/man/man1/npm-restart.1
+++ b/frontend/share/man/man1/npm-restart.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-restart.1

--- a/frontend/share/man/man1/npm-root.1
+++ b/frontend/share/man/man1/npm-root.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-root.1

--- a/frontend/share/man/man1/npm-run-script.1
+++ b/frontend/share/man/man1/npm-run-script.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-run-script.1

--- a/frontend/share/man/man1/npm-search.1
+++ b/frontend/share/man/man1/npm-search.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-search.1

--- a/frontend/share/man/man1/npm-shrinkwrap.1
+++ b/frontend/share/man/man1/npm-shrinkwrap.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-shrinkwrap.1

--- a/frontend/share/man/man1/npm-star.1
+++ b/frontend/share/man/man1/npm-star.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-star.1

--- a/frontend/share/man/man1/npm-stars.1
+++ b/frontend/share/man/man1/npm-stars.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-stars.1

--- a/frontend/share/man/man1/npm-start.1
+++ b/frontend/share/man/man1/npm-start.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-start.1

--- a/frontend/share/man/man1/npm-stop.1
+++ b/frontend/share/man/man1/npm-stop.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-stop.1

--- a/frontend/share/man/man1/npm-team.1
+++ b/frontend/share/man/man1/npm-team.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-team.1

--- a/frontend/share/man/man1/npm-test.1
+++ b/frontend/share/man/man1/npm-test.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-test.1

--- a/frontend/share/man/man1/npm-token.1
+++ b/frontend/share/man/man1/npm-token.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-token.1

--- a/frontend/share/man/man1/npm-uninstall.1
+++ b/frontend/share/man/man1/npm-uninstall.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-uninstall.1

--- a/frontend/share/man/man1/npm-unpublish.1
+++ b/frontend/share/man/man1/npm-unpublish.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-unpublish.1

--- a/frontend/share/man/man1/npm-update.1
+++ b/frontend/share/man/man1/npm-update.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-update.1

--- a/frontend/share/man/man1/npm-version.1
+++ b/frontend/share/man/man1/npm-version.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-version.1

--- a/frontend/share/man/man1/npm-view.1
+++ b/frontend/share/man/man1/npm-view.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-view.1

--- a/frontend/share/man/man1/npm-whoami.1
+++ b/frontend/share/man/man1/npm-whoami.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm-whoami.1

--- a/frontend/share/man/man1/npm.1
+++ b/frontend/share/man/man1/npm.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npm.1

--- a/frontend/share/man/man1/npx.1
+++ b/frontend/share/man/man1/npx.1
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man1/npx.1

--- a/frontend/share/man/man5/npm-folders.5
+++ b/frontend/share/man/man5/npm-folders.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/npm-folders.5

--- a/frontend/share/man/man5/npm-global.5
+++ b/frontend/share/man/man5/npm-global.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/npm-global.5

--- a/frontend/share/man/man5/npm-json.5
+++ b/frontend/share/man/man5/npm-json.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/npm-json.5

--- a/frontend/share/man/man5/npm-package-locks.5
+++ b/frontend/share/man/man5/npm-package-locks.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/npm-package-locks.5

--- a/frontend/share/man/man5/npm-shrinkwrap.json.5
+++ b/frontend/share/man/man5/npm-shrinkwrap.json.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/npm-shrinkwrap.json.5

--- a/frontend/share/man/man5/npmrc.5
+++ b/frontend/share/man/man5/npmrc.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/npmrc.5

--- a/frontend/share/man/man5/package-lock.json.5
+++ b/frontend/share/man/man5/package-lock.json.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/package-lock.json.5

--- a/frontend/share/man/man5/package.json.5
+++ b/frontend/share/man/man5/package.json.5
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man5/package.json.5

--- a/frontend/share/man/man7/npm-coding-style.7
+++ b/frontend/share/man/man7/npm-coding-style.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-coding-style.7

--- a/frontend/share/man/man7/npm-config.7
+++ b/frontend/share/man/man7/npm-config.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-config.7

--- a/frontend/share/man/man7/npm-developers.7
+++ b/frontend/share/man/man7/npm-developers.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-developers.7

--- a/frontend/share/man/man7/npm-disputes.7
+++ b/frontend/share/man/man7/npm-disputes.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-disputes.7

--- a/frontend/share/man/man7/npm-index.7
+++ b/frontend/share/man/man7/npm-index.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-index.7

--- a/frontend/share/man/man7/npm-orgs.7
+++ b/frontend/share/man/man7/npm-orgs.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-orgs.7

--- a/frontend/share/man/man7/npm-registry.7
+++ b/frontend/share/man/man7/npm-registry.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-registry.7

--- a/frontend/share/man/man7/npm-scope.7
+++ b/frontend/share/man/man7/npm-scope.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-scope.7

--- a/frontend/share/man/man7/npm-scripts.7
+++ b/frontend/share/man/man7/npm-scripts.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/npm-scripts.7

--- a/frontend/share/man/man7/removing-npm.7
+++ b/frontend/share/man/man7/removing-npm.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/removing-npm.7

--- a/frontend/share/man/man7/semver.7
+++ b/frontend/share/man/man7/semver.7
@@ -1,1 +1,0 @@
-../../../lib/node_modules/npm/man/man7/semver.7

--- a/recipe/meta.yaml.in
+++ b/recipe/meta.yaml.in
@@ -20,7 +20,6 @@ requirements:
   run:
     - python >3
     - vcs
-    - vcs-js
     - jupyterhub
 
 about:

--- a/src/components/LeftSideBar.tsx
+++ b/src/components/LeftSideBar.tsx
@@ -31,7 +31,6 @@ type LeftSideBarProps = {
     variables: string[]         // list of loaded variables
 };
 type LeftSideBarState = {
-    // file_path: string,          // path to the file in question
     variables: any,             // object of varnames: varinfo
     graphicsMethods: any,        // list of available graphicsmethods
     templates: any,             // list of availabe templates

--- a/src/components/LeftSideBar.tsx
+++ b/src/components/LeftSideBar.tsx
@@ -7,8 +7,6 @@ import VarList from './VarList';
 import GMList from './GMList';
 import TemplateList from './TemplateList';
 
-declare var vcs: any;
-
 const leftBtnStyle: React.CSSProperties = {
     margin: '5px',
     // float: 'left'
@@ -56,29 +54,7 @@ export class LeftSideBar extends React.Component<LeftSideBarProps, LeftSideBarSt
 
         this.handleVarClick = this.handleVarClick.bind(this);
         this.handleLoadVariable = this.handleLoadVariable.bind(this);
-        this.handleVcsLoad = this.handleVcsLoad.bind(this);
         this.updateListInfo = this.updateListInfo.bind(this);
-    }
-    // pass the vcs object to the VarList
-    handleVcsLoad() {
-        let vcs_target = $('#vcs-target')[0];
-        this.canvas = vcs.init(vcs_target);
-        if(!this.varListEl.current){
-            setTimeout(() => {
-                this.varListEl.current.setupVcs(vcs);
-            }, 500)
-        } else {
-            this.varListEl.current.setupVcs(vcs);
-        }
-    }
-    // setup the global vcs.js object
-    componentDidMount() {
-        console.log('starting vcs.js load');
-        let script = document.createElement('script');
-        script.src = `http://localhost:5000/vcs.js`;
-        script.async = true;
-        script.addEventListener('load', this.handleVcsLoad);
-        document.body.appendChild(script);
     }
     // handle click on a variable by opening dimension select modal
     handleVarClick(e: any) {

--- a/src/components/VarList.tsx
+++ b/src/components/VarList.tsx
@@ -21,7 +21,6 @@ type VarEditState = {
 
 class VarList extends React.Component<VarListProps, VarEditState> {
 
-    vcs: any;
     varLoader: VarLoader;
     constructor(props: VarListProps) {
         super(props);
@@ -35,13 +34,8 @@ class VarList extends React.Component<VarListProps, VarEditState> {
         this.addVariables = this.addVariables.bind(this);
         this.editVariable = this.editVariable.bind(this)
         this.removeVariable = this.removeVariable.bind(this)
-        this.setupVcs = this.setupVcs.bind(this);
         this.varClickHandler = this.varClickHandler.bind(this);
         this.callApi = this.callApi.bind(this);
-    }
-
-    setupVcs(vcs: any) {
-        this.vcs = vcs;
     }
 
     addVariables() {

--- a/src/components/VarList.tsx
+++ b/src/components/VarList.tsx
@@ -50,7 +50,6 @@ class VarList extends React.Component<VarListProps, VarEditState> {
         });
         let url = base_url + '/get_axis?' + params;
         this.callApi(url).then((variableAxes: any) => {
-            debugger;
             this.setState({
                 variables: variableAxes.vars,
                 axis: variableAxes.axes

--- a/src/components/VarList.tsx
+++ b/src/components/VarList.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import * as $ from 'jquery';
 import { toast } from 'react-toastify';
 import AddEditRemoveNav from './AddEditRemoveNav';
 import { VarLoader } from './VarLoader';
 import List from "./List";
+
+const base_url = '/vcs';
 
 type VarListProps = {
     file_path: string,  // path to the file we're loading variables from
@@ -34,6 +37,7 @@ class VarList extends React.Component<VarListProps, VarEditState> {
         this.removeVariable = this.removeVariable.bind(this)
         this.setupVcs = this.setupVcs.bind(this);
         this.varClickHandler = this.varClickHandler.bind(this);
+        this.callApi = this.callApi.bind(this);
     }
 
     setupVcs(vcs: any) {
@@ -41,16 +45,28 @@ class VarList extends React.Component<VarListProps, VarEditState> {
     }
 
     addVariables() {
-        this.vcs.allvariables(this.props.file_path).then((variableAxes: any) => {
+        let params = $.param({
+            file_path: this.props.file_path,
+        });
+        let url = base_url + '/get_axis?' + params;
+        this.callApi(url).then((variableAxes: any) => {
+            debugger;
             this.setState({
-                variables: variableAxes[0],
-                axis: variableAxes[1]
-            })
+                variables: variableAxes.vars,
+                axis: variableAxes.axes
+            });
             this.varLoader.toggle();
             this.varLoader.setVariables(
-                variableAxes[0],
-                variableAxes[1]);
+                variableAxes.vars,
+                variableAxes.axes);
         })
+    }
+    
+    callApi = async (url: string) => {
+        const response = await fetch(url);
+        const body = await response.json();
+        if (response.status !== 200) throw Error(body.message);
+        return body;
     }
 
     editVariable() {

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -167,7 +167,6 @@ export class LeftSideBarWidget extends Widget {
     }
     //This is where the code injection occurs in the current console.
     updateVars() {
-        debugger;
         if (!this.currentPanel) {
             // Create Console and inject code
             this.commands.execute('console:create', {

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -136,7 +136,16 @@ export class LeftSideBarWidget extends Widget {
             },
             // plot using the currently selected variable, gm, template
             plotAction: () => {
-                let plotString = `x.plot(${this.currentVariable}, ${this.currentGm}, ${this.currentTemplate})`;
+                this.currentPanel.console.inject('x.clear()');
+                let gm = this.currentGm;
+                let temp = this.currentTemplate;
+                if(!gm){
+                    gm = '"default"';
+                }
+                if(!temp){
+                    temp = '"default"';
+                }
+                let plotString = `x.plot(${this.currentVariable}, ${gm}, ${temp})`;
                 this.currentPanel.console.inject(plotString);
             },
             clearAction: () => {
@@ -158,6 +167,7 @@ export class LeftSideBarWidget extends Widget {
     }
     //This is where the code injection occurs in the current console.
     updateVars() {
+        debugger;
         if (!this.currentPanel) {
             // Create Console and inject code
             this.commands.execute('console:create', {
@@ -194,6 +204,11 @@ export class LeftSideBarWidget extends Widget {
         var dict: any = { variables: {}, templates: {}, graphicsMethods: {} };
         var outputElements = output.replace(/\'/g, "").split('|');
         dict.variables = outputElements[0].slice(1, -1).split(',');
+
+        let idx = dict.variables.indexOf(' selectedVariable')
+        if( idx != -1){
+            dict.variables.splice(idx, 1);
+        }
         dict.templates = outputElements[1].slice(1, -1).split(',');
 
         //var pattern = /?=\]\}\)/;
@@ -219,7 +234,10 @@ export class LeftSideBarWidget extends Widget {
     }
     handleGetVarsComplete() {
         //Once injection is done read output as string
-        var consoleOutputStr: string = document.getElementsByClassName("jp-OutputArea-output")[0].getElementsByTagName("pre")[0].innerHTML;
+        var consoleOutputStr: string;
+        var jpOutputAreas: HTMLCollectionOf<Element>;
+        jpOutputAreas = document.getElementsByClassName("jp-OutputArea-output");
+        consoleOutputStr = jpOutputAreas[jpOutputAreas.length - 1].getElementsByTagName("pre")[0].innerHTML;
         var outputObj = this.outputStrToDict(consoleOutputStr);
 
         this.component.updateListInfo(

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -136,17 +136,21 @@ export class LeftSideBarWidget extends Widget {
             },
             // plot using the currently selected variable, gm, template
             plotAction: () => {
-                this.currentPanel.console.inject('x.clear()');
-                let gm = this.currentGm;
-                let temp = this.currentTemplate;
-                if(!gm){
-                    gm = '"default"';
+                if(!this.currentVariable){
+                    this.currentPanel.console.inject('# Please select a variable from the left panel');
+                } else {
+                    this.currentPanel.console.inject('x.clear()');
+                    let gm = this.currentGm;
+                    let temp = this.currentTemplate;
+                    if(!gm){
+                        gm = '"default"';
+                    }
+                    if(!temp){
+                        temp = '"default"';
+                    }
+                    let plotString = `x.plot(${this.currentVariable}, ${gm}, ${temp})`;
+                    this.currentPanel.console.inject(plotString);
                 }
-                if(!temp){
-                    temp = '"default"';
-                }
-                let plotString = `x.plot(${this.currentVariable}, ${gm}, ${temp})`;
-                this.currentPanel.console.inject(plotString);
             },
             clearAction: () => {
                 this.currentPanel.console.clear();

--- a/vcs_backend/__init__.py
+++ b/vcs_backend/__init__.py
@@ -4,7 +4,7 @@ A server backend for handling jupyter-vcs frontend requests
 from notebook.utils import url_path_join
 
 import cdms2
-
+import numpy as np
 # from vcs_handlers import *
 
 __version__ = '0.0.1'
@@ -20,13 +20,101 @@ class VCSHandler(APIHandler):
     """
     @gen.coroutine
     def get(self, path=''):
+        """Return a list of variables from the given file name."""
         print('got a get request on path {}'.format(path))
         file_path = self.get_argument('file_path')
         print('file_path = ' + file_path)
-        datafile = cdms2.open(file_path)
-        response = { 'variables': [x for x in datafile.variables.keys()] }
+    
+        reader = cdms2.open(file_path)
+        outVars = {}
+        for vname in reader.variables:
+            var = reader.variables[vname]
+
+            # Get a displayable name for the variable
+            if hasattr(var, 'long_name'):
+                name = var.long_name
+            elif hasattr(var, 'title'):
+                name = var.title
+            elif hasattr(var, 'id'):
+                name = var.id
+            else:
+                name = vname
+            if hasattr(var, 'units'):
+                units = var.units
+            else:
+                units = 'Unknown'
+            axisList = []
+            for axis in var.getAxisList():
+                axisList.append(axis.id)
+            lonLat = None
+            if var.getLongitude() and var.getLatitude() and \
+                    not isinstance(var.getGrid(), cdms2.grid.AbstractRectGrid):
+                # for curvilinear and generic grids
+                # 1. getAxisList() returns the axes and
+                # 2. getLongitude() and getLatitude() return the lon,lat variables
+                lonName = var.getLongitude().id
+                latName = var.getLatitude().id
+                lonLat = [lonName, latName]
+                # add min/max for longitude/latitude
+                if (lonName not in outVars):
+                    outVars[lonName] = {}
+                lonData = var.getLongitude()[:]
+                outVars[lonName]['bounds'] =\
+                  [float(np.amin(lonData)), float(np.amax(lonData))]
+                if (latName not in outVars):
+                    outVars[latName] = {}
+                latData = var.getLatitude()[:]
+                outVars[latName]['bounds'] =\
+                  [float(np.amin(latData)), float(np.amax(latData))]
+            if (isinstance(var.getGrid(), cdms2.grid.AbstractRectGrid)):
+                gridType = 'rectilinear'
+            elif (isinstance(var.getGrid(), cdms2.hgrid.AbstractCurveGrid)):
+                gridType = 'curvilinear'
+            elif (isinstance(var.getGrid(), cdms2.gengrid.AbstractGenericGrid)):
+                gridType = 'generic'
+            else:
+                gridType = None
+            if (vname not in outVars):
+                outVars[vname] = {}
+            outVars[vname]['name'] = name
+            outVars[vname]['shape'] = var.shape
+            outVars[vname]['units'] = units
+            outVars[vname]['axisList'] = axisList
+            outVars[vname]['lonLat'] = lonLat
+            outVars[vname]['gridType'] = gridType
+            if ('bounds' not in outVars[vname]):
+                outVars[vname]['bounds'] = None
+        outAxes = {}
+        for aname in reader.axes:
+            axis = reader.axes[aname]
+
+            # Get a displayable name for the variable
+            if hasattr(axis, 'id'):
+                name = axis.id
+            else:
+                name = aname
+            if hasattr(axis, 'units'):
+                units = axis.units
+            else:
+                units = 'Unknown'
+            outAxes[aname] = {
+                'name': name,
+                'shape': axis.shape,
+                'units': units,
+                'modulo': axis.getModulo(),
+                'moduloCycle': axis.getModuloCycle(),
+                'data': axis.getData().tolist(),
+                'isTime': axis.isTime()
+            }
+        reader.close()
+        response = {
+            'vars': outVars,
+            'axes': outAxes
+        }
         print('sending response ' + str(response))
         self.write(response)
+    
+    
 
 def _jupyter_server_extension_paths():
     return [{
@@ -43,4 +131,4 @@ def load_jupyter_server_extension(nb_server_app):
     base_url = web_app.settings['base_url']
     endpoint = url_path_join(base_url, r'/vcs')
     handlers = [(endpoint + "(.*)", VCSHandler)]
-web_app.add_handlers('.*$', handlers)
+    web_app.add_handlers('.*$', handlers)


### PR DESCRIPTION
Fixes three issues:

1) When a user hits plot without first selecting a graphics method or template, uses the "default" for either instead of erroring.
2) After a plot has been run, the code that collected the variables/gms/templates would crash. This is because there was an assumption that the call to ```document.getElementsByClassName("jp-OutputArea-output")``` would return a single element array. Instead I changed it to collect the whole array, and just pop off the last element of it. This seams to have fixed the issue.
3) Removes the requirement to use vcs.js, and moves the call to an HTTP API call to the backend server extension.