### PR TITLE
Updated npm packages to remove vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -852,7 +852,6 @@
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -1305,9 +1304,9 @@
 			}
 		},
 		"debug": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-			"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
@@ -1448,12 +1447,6 @@
 				"is-obj": "^1.0.0"
 			}
 		},
-		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
-		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -1465,7 +1458,6 @@
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -1502,22 +1494,6 @@
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
 			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-		},
-		"event-stream": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-			"integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-			"dev": true,
-			"requires": {
-				"duplexer": "^0.1.1",
-				"flatmap-stream": "^0.1.0",
-				"from": "^0.1.7",
-				"map-stream": "0.0.7",
-				"pause-stream": "^0.0.11",
-				"split": "^1.0.1",
-				"stream-combiner": "^0.2.2",
-				"through": "^2.3.8"
-			}
 		},
 		"execa": {
 			"version": "0.7.0",
@@ -1689,6 +1665,18 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
 		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
 		"fbjs": {
 			"version": "0.8.17",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
@@ -1736,12 +1724,6 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
-		"flatmap-stream": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-			"integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-			"dev": true
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1755,25 +1737,14 @@
 			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "1.0.6",
+				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
-			},
-			"dependencies": {
-				"combined-stream": {
-					"version": "1.0.6",
-					"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-					"dev": true,
-					"requires": {
-						"delayed-stream": "~1.0.0"
-					}
-				}
 			}
 		},
 		"fragment-cache": {
@@ -1784,12 +1755,6 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
-		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -2377,7 +2342,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
@@ -2453,7 +2418,7 @@
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
@@ -2488,13 +2453,33 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
+				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.6.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+					"integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				}
 			}
 		},
 		"has-ansi": {
@@ -2706,7 +2691,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
@@ -2838,7 +2823,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -2933,9 +2918,9 @@
 			"integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
 		},
 		"js-base64": {
-			"version": "2.4.9",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-			"integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.0.tgz",
+			"integrity": "sha512-wlEBIZ5LP8usDylWbDNhKPEFVFdI5hCHpnVoT/Ysvoi/PRhJENm/Rlh9TvjYB38HFfKZN7OzEbRjmjvLkFw11g==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -2947,8 +2932,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"json-parser": {
 			"version": "1.1.5",
@@ -3031,7 +3015,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
@@ -3187,12 +3171,6 @@
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
 			"dev": true
 		},
-		"map-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-			"dev": true
-		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3247,18 +3225,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.36.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-			"integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.20",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-			"integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+			"version": "2.1.21",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.36.0"
+				"mime-db": "~1.37.0"
 			}
 		},
 		"minimatch": {
@@ -3272,7 +3250,7 @@
 		},
 		"minimist": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"mixin-deep": {
@@ -3298,7 +3276,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
@@ -3307,7 +3285,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				}
@@ -3315,7 +3293,7 @@
 		},
 		"moment": {
 			"version": "2.21.0",
-			"resolved": "http://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
 			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
 		},
 		"ms": {
@@ -3348,6 +3326,19 @@
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
 			}
+		},
+		"node": {
+			"version": "10.14.1",
+			"resolved": "https://registry.npmjs.org/node/-/node-10.14.1.tgz",
+			"integrity": "sha512-8zdaYPCiE4+aP+EUe3o0IRpuvoIC1IIrsWXlxfW5kWyQfBGwDHa/Y7TOZ/Pu3EjIUdWdeyuPhGmcS2tRW5kOPg==",
+			"requires": {
+				"node-bin-setup": "^1.0.0"
+			}
+		},
+		"node-bin-setup": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
+			"integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -3387,9 +3378,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
-			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
+			"integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -3407,7 +3398,7 @@
 				"nan": "^2.10.0",
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
-				"request": "2.87.0",
+				"request": "^2.88.0",
 				"sass-graph": "^2.2.4",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
@@ -3421,7 +3412,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
@@ -3446,21 +3437,21 @@
 			"integrity": "sha1-RyL6LhisTrc6Qq4W0B41hKErdTE="
 		},
 		"nodemon": {
-			"version": "1.18.4",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.4.tgz",
-			"integrity": "sha512-hyK6vl65IPnky/ee+D3IWvVGgJa/m3No2/Xc/3wanS6Ce1MWjCzH6NnhPJ/vZM+6JFym16jtHx51lmCMB9HDtg==",
+			"version": "1.18.9",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
+			"integrity": "sha512-oj/eEVTEI47pzYAjGkpcNw0xYwTl4XSTUQv2NPQI6PpN3b75PhpuYk3Vb3U80xHCyM2Jm+1j68ULHXl4OR3Afw==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.2",
+				"chokidar": "^2.0.4",
 				"debug": "^3.1.0",
 				"ignore-by-default": "^1.0.1",
 				"minimatch": "^3.0.4",
-				"pstree.remy": "^1.1.0",
+				"pstree.remy": "^1.1.6",
 				"semver": "^5.5.0",
 				"supports-color": "^5.2.0",
 				"touch": "^3.1.0",
 				"undefsafe": "^2.0.2",
-				"update-notifier": "^2.3.0"
+				"update-notifier": "^2.5.0"
 			}
 		},
 		"nopt": {
@@ -3520,9 +3511,9 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
 		"object-assign": {
@@ -3596,7 +3587,7 @@
 		},
 		"os-locale": {
 			"version": "1.4.0",
-			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
@@ -3701,15 +3692,6 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"dev": true,
-			"requires": {
-				"through": "~2.3"
-			}
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3794,34 +3776,28 @@
 				"warning": "^3.0.0"
 			}
 		},
-		"ps-tree": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-			"dev": true,
-			"requires": {
-				"event-stream": "~3.3.0"
-			}
-		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 			"dev": true
 		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
 		"pstree.remy": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
-			"integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
-			"dev": true,
-			"requires": {
-				"ps-tree": "^1.1.0"
-			}
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+			"integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
+			"dev": true
 		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
 		"qs": {
@@ -4256,31 +4232,31 @@
 			}
 		},
 		"request": {
-			"version": "2.87.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
+				"aws4": "^1.8.0",
 				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"uuid": "^3.3.2"
 			}
 		},
 		"require-directory": {
@@ -4629,9 +4605,9 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -4655,19 +4631,10 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
 			"dev": true
-		},
-		"split": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
-			"requires": {
-				"through": "2"
-			}
 		},
 		"split-string": {
 			"version": "3.1.0",
@@ -4688,9 +4655,9 @@
 			}
 		},
 		"sshpk": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+			"integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -4734,16 +4701,6 @@
 				"readable-stream": "^2.0.1"
 			}
 		},
-		"stream-combiner": {
-			"version": "0.2.2",
-			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-			"dev": true,
-			"requires": {
-				"duplexer": "~0.1.1",
-				"through": "~2.3.4"
-			}
-		},
 		"strict-uri-encode": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -4770,7 +4727,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
@@ -4834,12 +4791,6 @@
 			"requires": {
 				"execa": "^0.7.0"
 			}
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -4910,12 +4861,21 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
+				"psl": "^1.1.24",
 				"punycode": "^1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				}
 			}
 		},
 		"traverse": {
@@ -4951,8 +4911,7 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"typed-styles": {
 			"version": "0.0.5",
@@ -5112,6 +5071,15 @@
 				"xdg-basedir": "^3.0.0"
 			}
 		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -5212,9 +5180,9 @@
 			}
 		},
 		"widest-line": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
 			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
@@ -5255,7 +5223,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"bootstrap-slider": "^10.2.1",
 		"jquery": "^3.3.1",
 		"lodash": "^4.17.11",
+		"node": "^10.14.1",
 		"nodejs": "0.0.0",
 		"query-string": "^6.1.0",
 		"rc-slider": "^8.6.3",
@@ -68,8 +69,8 @@
 		"remove": "^0.1.5"
 	},
 	"devDependencies": {
-		"node-sass": "^4.9.3",
-		"nodemon": "^1.18.4",
+		"node-sass": "^4.11.0",
+		"nodemon": "^1.18.9",
 		"rimraf": "^2.6.1",
 		"typescript": "^2.9.2"
 	},


### PR DESCRIPTION
I was trying to install an npm package and wasn't able to due to issues with some dependencies. Upon further investigation I found out NPM removed a package which was labeled as malicious, which also relates to a warning I saw on github: 
https://github.com/CDAT/jupyter-vcdat/network/alert/package-lock.json/event-stream/open
I performed a few updates of the npm dependencies to remove the dependency that caused the issue. I also downgraded node from v11.5 to v10.14 because of another issue that was pointed out just last month: https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/2023