### PR TITLE
Code injection update

### DIFF
--- a/src/cell_utils.ts
+++ b/src/cell_utils.ts
@@ -95,7 +95,6 @@ namespace cell_utils {
         } catch (error) {
           reject(error);
         }
-        // Check the session is ready and continue with commands when it is
       } else {
         reject(
           new Error(
@@ -123,12 +122,12 @@ namespace cell_utils {
       try {
         if (command && notebook_panel) {
           let notebook = notebook_panel.content;
-          // Check the session is ready and continue with commands when it is
           await notebook_panel.session.ready;
           if (index >= 0 && index < notebook.widgets.length) {
             //Save the old index, then set the current active cell
             let oldIndex = notebook.activeCellIndex;
             notebook.activeCellIndex = index;
+            //Adjust old index to account for deleted cell.
             if (oldIndex == index) {
               if (oldIndex > 0) {
                 oldIndex -= 1;
@@ -176,7 +175,6 @@ namespace cell_utils {
       try {
         if (command && notebook_panel) {
           let notebook = notebook_panel.content;
-          // Check the session is ready and continue with commands when it is
           await notebook_panel.session.ready;
           //Save the old index, then set the current active cell
           let oldIndex = notebook.activeCellIndex;

--- a/src/cell_utils.ts
+++ b/src/cell_utils.ts
@@ -6,7 +6,7 @@ import { CommandRegistry } from "@phosphor/commands";
 /** Contains some utility functions for handling notebook cells */
 namespace cell_utils {
   /**
-   * Reads the output at a cell within the specified notebook and returns it as a string
+   * @description Reads the output at a cell within the specified notebook and returns it as a string
    * @param notebook The notebook to get the cell from
    * @param index The index of the cell to read
    * @returns any - A string value of the cell output from the specified
@@ -48,7 +48,7 @@ namespace cell_utils {
   }
 
   /**
-   * Gets the cell object at specified index in the notebook
+   * @description Gets the cell object at specified index in the notebook
    * @param notebook The notebook to get the cell from
    * @param index The index for the cell
    * @returns Cell - The cell at specified index
@@ -61,48 +61,41 @@ namespace cell_utils {
   }
 
   /**
-   * Runs code in the currently selected cell of the notebook
+   * @description Runs code in the currently selected cell of the notebook
    * @param command The command registry which can execute the run command.
    * @param notebook The notebook panel to run the cell in
    * @returns Promise<string> - A promise containing the output after the code has executed.
    */
-  export function runCellAtIndex(
+  export async function runCellAtIndex(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number
-  ) {
-    let prom: Promise<string> = new Promise((resolve, reject) => {
+  ): Promise<string> {
+    let prom: Promise<string> = new Promise(async (resolve, reject) => {
       if (command && notebook_panel) {
-        // Check the session is ready and continue with commands when it is
-        notebook_panel.session.ready
-          .then(() => {
-            let notebook = notebook_panel.content;
-            if (index >= 0 && index < notebook.widgets.length) {
-              //Save the old index, then set the current active cell
-              let oldIndex = notebook.activeCellIndex;
-              notebook.activeCellIndex = index;
-              command
-                .execute("notebook:run-cell")
-                .then(() => {
-                  try {
-                    let output = readOutput(notebook, index);
-                    notebook.activeCellIndex = oldIndex;
-                    resolve(output);
-                  } catch (error) {
-                    reject(error);
-                  }
-                })
-                .catch(error => {
-                  notebook.activeCellIndex = oldIndex;
-                  reject(error);
-                });
-            } else {
-              reject(new Error("The index was out of range."));
+        try {
+          await notebook_panel.session.ready;
+          let notebook = notebook_panel.content;
+          if (index >= 0 && index < notebook.widgets.length) {
+            //Save the old index, then set the current active cell
+            let oldIndex = notebook.activeCellIndex;
+            notebook.activeCellIndex = index;
+            try {
+              await command.execute("notebook:run-cell");
+              let output = readOutput(notebook, index);
+              notebook.activeCellIndex = oldIndex;
+              resolve(output);
+            } catch (error) {
+              notebook.activeCellIndex = oldIndex;
+              reject(error);
             }
-          })
-          .catch(error => {
-            reject(error);
-          });
+          } else {
+            reject(new Error("The index was out of range."));
+          }
+        } catch (error) {
+          reject(error);
+        }
+        // Check the session is ready and continue with commands when it is
       } else {
         reject(
           new Error(
@@ -115,67 +108,57 @@ namespace cell_utils {
   }
 
   /**
-   * Deletes the cell at specified index in the open notebook
+   * @description Deletes the cell at specified index in the open notebook
    * @param command The command registry which can execute the run command
    * @param notebook_panel The notebook panel to delete the cell from
    * @param index The index that the cell will be deleted at
    * @returns Promise<void> - A promise for when cell is deleted.
    */
-  export function deleteCellAtIndex(
+  export async function deleteCellAtIndex(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number
   ): Promise<void> {
-    let prom: Promise<void> = new Promise((resolve, reject) => {
-      if (command && notebook_panel) {
-        let notebook = notebook_panel.content;
-        // Check the session is ready and continue with commands when it is
-        notebook_panel.session.ready
-          .then(() => {
-            if (index >= 0 && index < notebook.widgets.length) {
-              //Save the old index, then set the current active cell
-              let oldIndex = notebook.activeCellIndex;
-              notebook.activeCellIndex = index;
-
-              if (oldIndex == index) {
-                if (oldIndex > 0) {
-                  oldIndex -= 1;
-                } else {
-                  oldIndex = 0;
-                }
-              } else if (oldIndex > index) {
+    let prom: Promise<void> = new Promise(async (resolve, reject) => {
+      try {
+        if (command && notebook_panel) {
+          let notebook = notebook_panel.content;
+          // Check the session is ready and continue with commands when it is
+          await notebook_panel.session.ready;
+          if (index >= 0 && index < notebook.widgets.length) {
+            //Save the old index, then set the current active cell
+            let oldIndex = notebook.activeCellIndex;
+            notebook.activeCellIndex = index;
+            if (oldIndex == index) {
+              if (oldIndex > 0) {
                 oldIndex -= 1;
+              } else {
+                oldIndex = 0;
               }
-              command
-                .execute("notebook:delete-cell")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve();
-                })
-                .catch(error => {
-                  notebook.activeCellIndex = oldIndex;
-                  reject(error);
-                });
-            } else {
-              reject(new Error("The index was out of range."));
+            } else if (oldIndex > index) {
+              oldIndex -= 1;
             }
-          })
-          .catch(error => {
-            reject(error);
-          });
-      } else {
-        reject(
-          new Error(
-            "Null or undefined parameter was given for command or notebook argument."
-          )
-        );
+            await command.execute("notebook:delete-cell");
+            resolve();
+          } else {
+            reject(new Error("The index was out of range."));
+          }
+        } else {
+          reject(
+            new Error(
+              "Null or undefined parameter was given for command or notebook argument."
+            )
+          );
+        }
+      } catch (error) {
+        reject(error);
       }
     });
     return prom;
   }
 
   /**
-   * Inserts a cell into the notebook, the new cell will be at the specified index.
+   * @description Inserts a cell into the notebook, the new cell will be at the specified index.
    * If the cell is inserted at the currently active cell index, the active cell will be moved down by 1.
    * @param command The command registry which can execute the run command
    * @param notebook_panel The notebook panel to insert the cell in
@@ -184,77 +167,55 @@ namespace cell_utils {
    * If the cell index is greater than the last index, it will be added at the bottom.
    * @returns Promise<number> - A promise for when the cell is inserted, and at what index it was inserted
    */
-  export function insertCellAtIndex(
+  export async function insertCellAtIndex(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number
   ): Promise<number> {
-    let prom: Promise<number> = new Promise((resolve, reject) => {
-      if (command && notebook_panel) {
-        let notebook = notebook_panel.content;
-        // Check the session is ready and continue with commands when it is
-        notebook_panel.session.ready
-          .then(() => {
-            //Save the old index, then set the current active cell
-            let oldIndex = notebook.activeCellIndex;
+    let prom: Promise<number> = new Promise(async (resolve, reject) => {
+      try {
+        if (command && notebook_panel) {
+          let notebook = notebook_panel.content;
+          // Check the session is ready and continue with commands when it is
+          await notebook_panel.session.ready;
+          //Save the old index, then set the current active cell
+          let oldIndex = notebook.activeCellIndex;
+          //Adjust old index for cells inserted above active cell.
+          if (oldIndex >= index) {
+            oldIndex++;
+          }
+          if (index <= 0) {
+            notebook.activeCellIndex = 0;
+            await command.execute("notebook:insert-cell-above");
+            notebook.activeCellIndex = oldIndex;
+            resolve(0);
+          } else if (index >= notebook.widgets.length) {
+            notebook.activeCellIndex = notebook.widgets.length - 1;
+            await command.execute("notebook:insert-cell-below");
+            notebook.activeCellIndex = oldIndex;
+            resolve(notebook.widgets.length - 1);
+          } else {
+            notebook.activeCellIndex = index;
+            await command.execute("notebook:insert-cell-above");
 
-            //Adjust old index for cells inserted above active cell.
-            if (oldIndex >= index) {
-              oldIndex++;
-            }
-
-            if (index <= 0) {
-              notebook.activeCellIndex = 0;
-              command
-                .execute("notebook:insert-cell-above")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve(0);
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            } else if (index >= notebook.widgets.length) {
-              notebook.activeCellIndex = notebook.widgets.length - 1;
-              command
-                .execute("notebook:insert-cell-below")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve(notebook.widgets.length - 1);
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            } else {
-              notebook.activeCellIndex = index;
-              command
-                .execute("notebook:insert-cell-above")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve(index);
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            }
-          })
-          .catch(error => {
-            reject(error);
-          });
-      } else {
-        reject(
-          new Error(
-            "Null or undefined parameter was given for command or notebook argument."
-          )
-        );
-      }
+            notebook.activeCellIndex = oldIndex;
+            resolve(index);
+          }
+        } else {
+          reject(
+            new Error(
+              "Null or undefined parameter was given for command or notebook argument."
+            )
+          );
+        }
+      } catch (error) {}
     });
 
     return prom;
   }
 
   /**
-   * Injects code into the specified cell of a notebook, does not run the code.
+   * @description Injects code into the specified cell of a notebook, does not run the code.
    * Warning: the existing cell's code/text will be overwritten.
    * @param notebook The notebook to select the cell from
    * @param index The index of the cell to inject the code into
@@ -287,7 +248,7 @@ namespace cell_utils {
   }
 
   /**
-   * This will insert a new cell at the specified index and the inject the specified code into it.
+   * @description This will insert a new cell at the specified index and the inject the specified code into it.
    * @param command The command registry which can execute the insert command
    * @param notebook The notebook to insert the cell into
    * @param index The index of where the new cell will be inserted.
@@ -296,31 +257,26 @@ namespace cell_utils {
    * @param code The code to inject into the cell after it has been inserted
    * @returns Promise<number> - A promise for when the cell is ready, and at what index it was inserted
    */
-  export function insertInjectCode(
+  export async function insertInjectCode(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number,
     code: string
   ): Promise<number> {
-    let prom: Promise<number> = new Promise((resolve, reject) => {
-      insertCellAtIndex(command, notebook_panel, index)
-        .then(insertionIndex => {
-          try {
-            injectCodeAtIndex(notebook_panel.content, insertionIndex, code);
-            resolve(insertionIndex);
-          } catch (error) {
-            reject(error);
-          }
-        })
-        .catch(error => {
-          reject(error);
-        });
+    let prom: Promise<number> = new Promise(async (resolve, reject) => {
+      try {
+        let newIndex = await insertCellAtIndex(command, notebook_panel, index);
+        injectCodeAtIndex(notebook_panel.content, newIndex, code);
+        resolve(newIndex);
+      } catch (error) {
+        reject(error);
+      }
     });
     return prom;
   }
 
   /**
-   * This will insert a new cell at the specified index, inject the specified code into it and the run the code.
+   * @description This will insert a new cell at the specified index, inject the specified code into it and the run the code.
    * @param command The command registry which can execute the insert command
    * @param notebook_panel The notebook to insert the cell into
    * @param index The index of where the new cell will be inserted and run.
@@ -331,7 +287,7 @@ namespace cell_utils {
    * @returns Promise<[number, string]> - A promise for when the cell code has executed
    * containing the cell's index and output result
    */
-  export function insertAndRun(
+  export async function insertAndRun(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number,
@@ -367,7 +323,9 @@ namespace cell_utils {
   }
 
   /**
-   * This will insert a cell with specified code at the top and run the code.
+   * @deprecated Using notebook_utils.sendSimpleKernelRequest or notebook_utils.sendKernelRequest
+   * will execute code directly in the kernel without the need to create a cell and delete it.
+   * @description This will insert a cell with specified code at the top and run the code.
    * Once the code is run and output received, the cell is deleted, giving back cell's output.
    * If the code results in an error, the injected cell is still deleted but the promise will be rejected.
    * @param command The command registry
@@ -376,30 +334,30 @@ namespace cell_utils {
    * @param insertAtEnd True means the cell will be inserted at the bottom
    * @returns Promise<string> - A promise when the cell has been deleted, containing the execution result as a string
    */
-  export function runAndDelete(
+  export async function runAndDelete(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     code: string,
     insertAtEnd = true
   ): Promise<string> {
-    let prom: Promise<string> = new Promise((resolve, reject) => {
+    let prom: Promise<string> = new Promise(async (resolve, reject) => {
       let index: number = -1;
-      if (insertAtEnd) {
-        index = notebook_panel.content.model.cells.length;
+      try {
+        if (insertAtEnd) {
+          index = notebook_panel.content.model.cells.length;
+        }
+        let result: [number, string] = await insertAndRun(
+          command,
+          notebook_panel,
+          index,
+          code,
+          true
+        );
+        await deleteCellAtIndex(command, notebook_panel, result[0]);
+        resolve(result[1]);
+      } catch (error) {
+        reject(error);
       }
-      insertAndRun(command, notebook_panel, index, code, true)
-        .then(result => {
-          deleteCellAtIndex(command, notebook_panel, result[0])
-            .then(() => {
-              resolve(result[1]);
-            })
-            .catch(error => {
-              reject(error);
-            });
-        })
-        .catch(error => {
-          reject(error);
-        });
     });
     return prom;
   }

--- a/src/components/VarLoader.tsx
+++ b/src/components/VarLoader.tsx
@@ -8,8 +8,6 @@ import {
   Button,
   Row,
   Col,
-  FormGroup,
-  Input
 } from "reactstrap";
 
 import { DimensionSlider } from "./DimensionSlider";

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -20,17 +20,27 @@ def list_all():\n\
     out["gm"] = graphic_methods()\n\
     out["template"] = templates()\n\
     return out\n\
-print("{}|{}|{})".format(variables(),templates(),graphic_methods()))';
+output = "{}|{}|{})".format(variables(),templates(),graphic_methods())';
+
+const REFRESH_VARS_CMD =
+  "import __main__\n\
+def variables():\n\
+    out = []\n\
+    for nm, obj in __main__.__dict__.items():\n\
+        if isinstance(obj, cdms2.MV2.TransientVariable):\n\
+            out+=[nm]\n\
+    return out\n\
+output = variables()";
 
 const REQUIRED_MODULES = "'lazy_import','cdms2','vcs'";
 
 const CHECK_MODULES_CMD = `import sys\n\
 all_modules = [${REQUIRED_MODULES}]\n\
-missed_modules = []\n\
+output = []\n\
 for module in all_modules:\n\
 	if module not in sys.modules:\n\
-		missed_modules.append(module)\n\
-missed_modules`;
+		output.append(module)\n\
+output`;
 
 const BASE_URL = "/vcs";
 
@@ -39,6 +49,7 @@ const FILE_PATH_KEY = "vcdat_file_path";
 
 export {
   GET_VARS_CMD,
+  REFRESH_VARS_CMD,
   CHECK_MODULES_CMD,
   REQUIRED_MODULES,
   BASE_URL,

--- a/src/notebook_utils.ts
+++ b/src/notebook_utils.ts
@@ -105,8 +105,11 @@ namespace notebook_utils {
           let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
             {
               code: code,
+              silent: false,
+              store_history: store_history,
               user_expressions: { result: "output" },
-              store_history: store_history
+              allow_stdin: false,
+              stop_on_error: false
             }
           ).done;
           let content: any = message.content;
@@ -139,8 +142,14 @@ namespace notebook_utils {
    * @param notebook_panel The notebook to run the code in.
    * @param code The code to run in the kernel.
    * @param user_expressions The expressions used to capture the desired info from the executed code.
+   * @param silent Default is false. If true, kernel will execute as quietly as possible.
+   * store_history will be set to false, and no broadcast on IOPUB channel will be made.
    * @param store_history Default is false. If true, the code executed will be stored in the kernel's history
    * and the counter which is shown in the cells will be incremented to reflect code was run.
+   * @param allow_stdin Default is false. If true, code running in kernel can prompt user for input using
+   * an input_request message.
+   * @param stop_on_error Default is false. If True, does not abort the execution queue, if an exception is encountered.
+   * This allows the queued execution of multiple execute_requests, even if they generate exceptions.
    * @returns Promise<any> - A promise containing the execution results of the code as an object with
    * keys based on the user_expressions.
    * @example
@@ -163,7 +172,10 @@ namespace notebook_utils {
     notebook_panel: NotebookPanel,
     code: string,
     user_expressions: any,
-    store_history: boolean = false
+    silent: boolean = false,
+    store_history: boolean = false,
+    allow_stdin: boolean = false,
+    stop_on_error: boolean = false
   ): Promise<any> {
     let prom: Promise<any> = new Promise(async (resolve, reject) => {
       // Check notebook panel is ready
@@ -175,8 +187,11 @@ namespace notebook_utils {
           let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
             {
               code: code,
+              silent: silent,
+              store_history: store_history,
               user_expressions: user_expressions,
-              store_history: store_history
+              allow_stdin: allow_stdin,
+              stop_on_error: stop_on_error
             }
           ).done;
           let content: any = message.content;

--- a/src/notebook_utils.ts
+++ b/src/notebook_utils.ts
@@ -1,63 +1,61 @@
-import { Notebook, NotebookPanel } from "@jupyterlab/notebook";
+import { NotebookPanel } from "@jupyterlab/notebook";
 import { CommandRegistry } from "@phosphor/commands";
+import { KernelMessage } from "@jupyterlab/services";
 
 /** Contains utility functions for manipulating/handling notebooks in the application. */
 namespace notebook_utils {
   /**
-   * Creates a new JupyterLab notebook for use by the application
+   * @description Creates a new JupyterLab notebook for use by the application
    * @param command The command registry
    * @returns A promise containing the notebook panel object that was created (if successful).
    */
-  export function createNewNotebook(
+  export async function createNewNotebook(
     command: CommandRegistry
   ): Promise<NotebookPanel> {
-    let prom: Promise<NotebookPanel> = new Promise((resolve, reject) => {
-      command
-        .execute("notebook:create-new", {
+    let prom: Promise<NotebookPanel> = new Promise(async (resolve, reject) => {
+      try {
+        let notebook: any = await command.execute("notebook:create-new", {
           activate: true,
           path: "",
           preferredLanguage: ""
-        })
-        .then(notebook => {
-          notebook.session.ready.then(() => {
-            resolve(notebook);
-          });
-        })
-        .catch(error => {
-          reject(error);
         });
+        await notebook.session.ready;
+        resolve(notebook);
+      } catch (error) {
+        reject(error);
+      }
     });
     return prom;
   }
 
   /**
-   * Gets the value of a key from specified notebook's metadata. Returns null if the key doesn't exist.
+   * @description Gets the value of a key from specified notebook's metadata. Returns null if the key doesn't exist.
    * Checks the notebook session is ready before getting the metadata.
    * @param notebook_panel The notebook to get meta data from.
    * @param key The key of the value.
    * @returns The value of the metadata.
    */
-  export function getMetaData(
+  export async function getMetaData(
     notebook_panel: NotebookPanel,
     key: string
   ): Promise<any> {
-    return new Promise((resolve, reject) => {
-      notebook_panel.session.ready
-        .then(() => {
-          if (notebook_panel.content.model.metadata.has(key)) {
-            resolve(notebook_panel.content.model.metadata.get(key));
-          } else {
-            return resolve(null);
-          }
-        })
-        .catch(error => {
-          reject(error);
-        });
+    let prom: Promise<any> = new Promise(async (resolve, reject) => {
+      try {
+        await notebook_panel.session.ready;
+        if (notebook_panel.content.model.metadata.has(key)) {
+          resolve(notebook_panel.content.model.metadata.get(key));
+        } else {
+          return resolve(null);
+        }
+      } catch (error) {
+        reject(error);
+      }
     });
+    return prom;
   }
 
   /**
-   * Sets the key value pair in the notebook's metadata. If the key doesn't exists it will add one.
+   * @description Sets the key value pair in the notebook's metadata. If the key doesn't exists it will add one.
    * Checks the notebook session is ready before getting the metadata.
    * @param notebook_panel The notebook to set meta data in.
    * @param key The key of the value to create.
@@ -69,15 +67,132 @@ namespace notebook_utils {
     key: string,
     value: any
   ): Promise<any> {
-    return new Promise((resolve, reject) => {
-      notebook_panel.session.ready
-        .then(() => {
-          resolve(notebook_panel.content.model.metadata.set(key, value));
-        })
-        .catch(error => {
-          reject(error);
-        });
+    let prom: Promise<any> = new Promise(async (resolve, reject) => {
+      try {
+        await notebook_panel.session.ready;
+        resolve(notebook_panel.content.model.metadata.set(key, value));
+      } catch (error) {
+        reject(error);
+      }
     });
+    return prom;
+  }
+
+  /**
+   * @description This function runs code directly in the notebook's kernel and then evaluates the
+   * result and returns it as a promise.
+   * @param notebook_panel The notebook to run the code in
+   * @param code The code to run in the kernel, this code needs to evaluate to a variable named 'output'
+   * Examples of valid code:
+   *  Single line: "output=123+456"
+   *  Multilines: "a = [1,2,3]\nb = [4,5,6]\nfor idx, val in enumerate(a):\n\tb[idx]+=val\noutput = b"
+   * @param store_history Default is false. If true, the code executed will be stored in the kernel's history
+   * and the counter which is shown in the cells will be incremented to reflect code was run.
+   * @returns Promise<string> - A promise containing the execution results of the code as a string.
+   */
+  export async function sendSimpleKernelRequest(
+    notebook_panel: NotebookPanel,
+    code: string,
+    store_history: boolean = false
+  ): Promise<string> {
+    let prom: Promise<string> = new Promise(async (resolve, reject) => {
+      // Check notebook panel is ready
+      if (notebook_panel) {
+        try {
+          // Wait for kernel to be ready before sending request
+          await notebook_panel.session.ready;
+          await notebook_panel.session.kernel.ready;
+          let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
+            {
+              code: code,
+              user_expressions: { result: "output" },
+              store_history: store_history
+            }
+          ).done;
+          let content: any = message.content;
+          if (content["status"] == "ok") {
+            let output = content["user_expressions"]["result"];
+            if (output) {
+              //Output has data
+              let execResult: string = output["data"]["text/plain"];
+              resolve(execResult);
+            } else {
+              //Output was empty
+              resolve("");
+            }
+          } else {
+            reject(content);
+          }
+        } catch (error) {
+          reject(error);
+        }
+      } else {
+        reject(new Error("The notebook panel is null or undefined."));
+      }
+    });
+    return prom;
+  }
+
+  /**
+   * @description This function runs code directly in the notebook's kernel and then evaluates the
+   * result and returns it as a promise.
+   * @param notebook_panel The notebook to run the code in.
+   * @param code The code to run in the kernel.
+   * @param user_expressions The expressions used to capture the desired info from the executed code.
+   * @param store_history Default is false. If true, the code executed will be stored in the kernel's history
+   * and the counter which is shown in the cells will be incremented to reflect code was run.
+   * @returns Promise<any> - A promise containing the execution results of the code as an object with
+   * keys based on the user_expressions.
+   * @example
+   * //The code
+   * const code = "a=123\nb=456\nsum=a+b";
+   * //The user expressions
+   * const expr = {sum: "sum",prod: "a*b",args:"[a,b,sum]"};
+   * //Async function call (returns a promise)
+   * sendKernelRequest(notebook_panel, code, expr,false);
+   * //Result when promise resolves:
+   * {
+   *  sum:{status:"ok",data:{"text/plain":"579"},metadata:{}},
+   *  prod:{status:"ok",data:{"text/plain":"56088"},metadata:{}},
+   *  args:{status:"ok",data:{"text/plain":"[123, 456, 579]"}}
+   * }
+   * @see For more information on JupyterLab messages:
+   * https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-results
+   */
+  export async function sendKernelRequest(
+    notebook_panel: NotebookPanel,
+    code: string,
+    user_expressions: any,
+    store_history: boolean = false
+  ): Promise<any> {
+    let prom: Promise<any> = new Promise(async (resolve, reject) => {
+      // Check notebook panel is ready
+      if (notebook_panel) {
+        try {
+          // Wait for kernel to be ready before sending request
+          await notebook_panel.session.ready;
+          await notebook_panel.session.kernel.ready;
+          let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
+            {
+              code: code,
+              user_expressions: user_expressions,
+              store_history: store_history
+            }
+          ).done;
+          let content: any = message.content;
+          if (content["status"] == "ok") {
+            resolve(content.user_expressions);
+          } else {
+            reject(content);
+          }
+        } catch (error) {
+          reject(error);
+        }
+      } else {
+        reject(new Error("The notebook panel is null or undefined."));
+      }
+    });
+    return prom;
   }
 }
 


### PR DESCRIPTION
This update contains the following changes:
--Additional notebook_utils functions which allow running code directly in kernel and getting the output. This avoids having to inject code in a cell, run then delete the cell.
--Updates in all cell_utils and notebook_utils functions, to improve readability and conciseness.
--Some bug fixes and better error capture
--Added new handlers which allow tracking of when user switches cells or when code is run in a cell.
--Added functionality that allows access of current available variables (as a string) in the active notebook. The variables are refreshed whenever user runs code (if the notebook has vcs ready and kernel is idle). This eliminates the need for a refresh button. 