### PR TITLE
Notebook init fixes

### DIFF
--- a/src/cell_utils.ts
+++ b/src/cell_utils.ts
@@ -95,7 +95,6 @@ namespace cell_utils {
         } catch (error) {
           reject(error);
         }
-        // Check the session is ready and continue with commands when it is
       } else {
         reject(
           new Error(
@@ -123,12 +122,12 @@ namespace cell_utils {
       try {
         if (command && notebook_panel) {
           let notebook = notebook_panel.content;
-          // Check the session is ready and continue with commands when it is
           await notebook_panel.session.ready;
           if (index >= 0 && index < notebook.widgets.length) {
             //Save the old index, then set the current active cell
             let oldIndex = notebook.activeCellIndex;
             notebook.activeCellIndex = index;
+            //Adjust old index to account for deleted cell.
             if (oldIndex == index) {
               if (oldIndex > 0) {
                 oldIndex -= 1;
@@ -176,7 +175,6 @@ namespace cell_utils {
       try {
         if (command && notebook_panel) {
           let notebook = notebook_panel.content;
-          // Check the session is ready and continue with commands when it is
           await notebook_panel.session.ready;
           //Save the old index, then set the current active cell
           let oldIndex = notebook.activeCellIndex;

--- a/src/cell_utils.ts
+++ b/src/cell_utils.ts
@@ -1,4 +1,4 @@
-import { Cell, ICellModel, isCodeCellModel } from "@jupyterlab/cells";
+import { ICellModel, isCodeCellModel } from "@jupyterlab/cells";
 import { Notebook, NotebookPanel } from "@jupyterlab/notebook";
 import { nbformat } from "@jupyterlab/coreutils";
 import { CommandRegistry } from "@phosphor/commands";
@@ -99,6 +99,32 @@ namespace cell_utils {
       }
     }
     throw new Error(msg);
+  }
+
+  /**
+   * @description Looks within the notebook for a cell containing the specified meta key
+   * @param notebook The notebook to search in
+   * @param key The metakey to search for
+   * @returns [number, ICellModel] - A pair of values, the first is the index of where the cell was found
+   * and the second is a reference to the cell itself. Returns [-1, null] if cell not found.
+   */
+  export function findCellWithMetaKey(
+    notebook: Notebook,
+    key: string
+  ): [number, ICellModel] {
+    const iter = notebook.model.cells.iter();
+    let index = 0;
+    for (
+      let nextVal = iter.next();
+      iter.next() !== undefined;
+      nextVal = iter.next()
+    ) {
+      if (nextVal.metadata.has(key)) {
+        return [index, nextVal];
+      }
+      index++;
+    }
+    return [-1, null];
   }
 
   /**

--- a/src/cell_utils.ts
+++ b/src/cell_utils.ts
@@ -6,7 +6,7 @@ import { CommandRegistry } from "@phosphor/commands";
 /** Contains some utility functions for handling notebook cells */
 namespace cell_utils {
   /**
-   * Reads the output at a cell within the specified notebook and returns it as a string
+   * @description Reads the output at a cell within the specified notebook and returns it as a string
    * @param notebook The notebook to get the cell from
    * @param index The index of the cell to read
    * @returns any - A string value of the cell output from the specified
@@ -48,7 +48,7 @@ namespace cell_utils {
   }
 
   /**
-   * Gets the cell object at specified index in the notebook
+   * @description Gets the cell object at specified index in the notebook
    * @param notebook The notebook to get the cell from
    * @param index The index for the cell
    * @returns Cell - The cell at specified index
@@ -61,48 +61,41 @@ namespace cell_utils {
   }
 
   /**
-   * Runs code in the currently selected cell of the notebook
+   * @description Runs code in the currently selected cell of the notebook
    * @param command The command registry which can execute the run command.
    * @param notebook The notebook panel to run the cell in
    * @returns Promise<string> - A promise containing the output after the code has executed.
    */
-  export function runCellAtIndex(
+  export async function runCellAtIndex(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number
-  ) {
-    let prom: Promise<string> = new Promise((resolve, reject) => {
+  ): Promise<string> {
+    let prom: Promise<string> = new Promise(async (resolve, reject) => {
       if (command && notebook_panel) {
-        // Check the session is ready and continue with commands when it is
-        notebook_panel.session.ready
-          .then(() => {
-            let notebook = notebook_panel.content;
-            if (index >= 0 && index < notebook.widgets.length) {
-              //Save the old index, then set the current active cell
-              let oldIndex = notebook.activeCellIndex;
-              notebook.activeCellIndex = index;
-              command
-                .execute("notebook:run-cell")
-                .then(() => {
-                  try {
-                    let output = readOutput(notebook, index);
-                    notebook.activeCellIndex = oldIndex;
-                    resolve(output);
-                  } catch (error) {
-                    reject(error);
-                  }
-                })
-                .catch(error => {
-                  notebook.activeCellIndex = oldIndex;
-                  reject(error);
-                });
-            } else {
-              reject(new Error("The index was out of range."));
+        try {
+          await notebook_panel.session.ready;
+          let notebook = notebook_panel.content;
+          if (index >= 0 && index < notebook.widgets.length) {
+            //Save the old index, then set the current active cell
+            let oldIndex = notebook.activeCellIndex;
+            notebook.activeCellIndex = index;
+            try {
+              await command.execute("notebook:run-cell");
+              let output = readOutput(notebook, index);
+              notebook.activeCellIndex = oldIndex;
+              resolve(output);
+            } catch (error) {
+              notebook.activeCellIndex = oldIndex;
+              reject(error);
             }
-          })
-          .catch(error => {
-            reject(error);
-          });
+          } else {
+            reject(new Error("The index was out of range."));
+          }
+        } catch (error) {
+          reject(error);
+        }
+        // Check the session is ready and continue with commands when it is
       } else {
         reject(
           new Error(
@@ -115,67 +108,57 @@ namespace cell_utils {
   }
 
   /**
-   * Deletes the cell at specified index in the open notebook
+   * @description Deletes the cell at specified index in the open notebook
    * @param command The command registry which can execute the run command
    * @param notebook_panel The notebook panel to delete the cell from
    * @param index The index that the cell will be deleted at
    * @returns Promise<void> - A promise for when cell is deleted.
    */
-  export function deleteCellAtIndex(
+  export async function deleteCellAtIndex(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number
   ): Promise<void> {
-    let prom: Promise<void> = new Promise((resolve, reject) => {
-      if (command && notebook_panel) {
-        let notebook = notebook_panel.content;
-        // Check the session is ready and continue with commands when it is
-        notebook_panel.session.ready
-          .then(() => {
-            if (index >= 0 && index < notebook.widgets.length) {
-              //Save the old index, then set the current active cell
-              let oldIndex = notebook.activeCellIndex;
-              notebook.activeCellIndex = index;
-
-              if (oldIndex == index) {
-                if (oldIndex > 0) {
-                  oldIndex -= 1;
-                } else {
-                  oldIndex = 0;
-                }
-              } else if (oldIndex > index) {
+    let prom: Promise<void> = new Promise(async (resolve, reject) => {
+      try {
+        if (command && notebook_panel) {
+          let notebook = notebook_panel.content;
+          // Check the session is ready and continue with commands when it is
+          await notebook_panel.session.ready;
+          if (index >= 0 && index < notebook.widgets.length) {
+            //Save the old index, then set the current active cell
+            let oldIndex = notebook.activeCellIndex;
+            notebook.activeCellIndex = index;
+            if (oldIndex == index) {
+              if (oldIndex > 0) {
                 oldIndex -= 1;
+              } else {
+                oldIndex = 0;
               }
-              command
-                .execute("notebook:delete-cell")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve();
-                })
-                .catch(error => {
-                  notebook.activeCellIndex = oldIndex;
-                  reject(error);
-                });
-            } else {
-              reject(new Error("The index was out of range."));
+            } else if (oldIndex > index) {
+              oldIndex -= 1;
             }
-          })
-          .catch(error => {
-            reject(error);
-          });
-      } else {
-        reject(
-          new Error(
-            "Null or undefined parameter was given for command or notebook argument."
-          )
-        );
+            await command.execute("notebook:delete-cell");
+            resolve();
+          } else {
+            reject(new Error("The index was out of range."));
+          }
+        } else {
+          reject(
+            new Error(
+              "Null or undefined parameter was given for command or notebook argument."
+            )
+          );
+        }
+      } catch (error) {
+        reject(error);
       }
     });
     return prom;
   }
 
   /**
-   * Inserts a cell into the notebook, the new cell will be at the specified index.
+   * @description Inserts a cell into the notebook, the new cell will be at the specified index.
    * If the cell is inserted at the currently active cell index, the active cell will be moved down by 1.
    * @param command The command registry which can execute the run command
    * @param notebook_panel The notebook panel to insert the cell in
@@ -184,77 +167,55 @@ namespace cell_utils {
    * If the cell index is greater than the last index, it will be added at the bottom.
    * @returns Promise<number> - A promise for when the cell is inserted, and at what index it was inserted
    */
-  export function insertCellAtIndex(
+  export async function insertCellAtIndex(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number
   ): Promise<number> {
-    let prom: Promise<number> = new Promise((resolve, reject) => {
-      if (command && notebook_panel) {
-        let notebook = notebook_panel.content;
-        // Check the session is ready and continue with commands when it is
-        notebook_panel.session.ready
-          .then(() => {
-            //Save the old index, then set the current active cell
-            let oldIndex = notebook.activeCellIndex;
+    let prom: Promise<number> = new Promise(async (resolve, reject) => {
+      try {
+        if (command && notebook_panel) {
+          let notebook = notebook_panel.content;
+          // Check the session is ready and continue with commands when it is
+          await notebook_panel.session.ready;
+          //Save the old index, then set the current active cell
+          let oldIndex = notebook.activeCellIndex;
+          //Adjust old index for cells inserted above active cell.
+          if (oldIndex >= index) {
+            oldIndex++;
+          }
+          if (index <= 0) {
+            notebook.activeCellIndex = 0;
+            await command.execute("notebook:insert-cell-above");
+            notebook.activeCellIndex = oldIndex;
+            resolve(0);
+          } else if (index >= notebook.widgets.length) {
+            notebook.activeCellIndex = notebook.widgets.length - 1;
+            await command.execute("notebook:insert-cell-below");
+            notebook.activeCellIndex = oldIndex;
+            resolve(notebook.widgets.length - 1);
+          } else {
+            notebook.activeCellIndex = index;
+            await command.execute("notebook:insert-cell-above");
 
-            //Adjust old index for cells inserted above active cell.
-            if (oldIndex >= index) {
-              oldIndex++;
-            }
-
-            if (index <= 0) {
-              notebook.activeCellIndex = 0;
-              command
-                .execute("notebook:insert-cell-above")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve(0);
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            } else if (index >= notebook.widgets.length) {
-              notebook.activeCellIndex = notebook.widgets.length - 1;
-              command
-                .execute("notebook:insert-cell-below")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve(notebook.widgets.length - 1);
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            } else {
-              notebook.activeCellIndex = index;
-              command
-                .execute("notebook:insert-cell-above")
-                .then(() => {
-                  notebook.activeCellIndex = oldIndex;
-                  resolve(index);
-                })
-                .catch(error => {
-                  reject(error);
-                });
-            }
-          })
-          .catch(error => {
-            reject(error);
-          });
-      } else {
-        reject(
-          new Error(
-            "Null or undefined parameter was given for command or notebook argument."
-          )
-        );
-      }
+            notebook.activeCellIndex = oldIndex;
+            resolve(index);
+          }
+        } else {
+          reject(
+            new Error(
+              "Null or undefined parameter was given for command or notebook argument."
+            )
+          );
+        }
+      } catch (error) {}
     });
 
     return prom;
   }
 
   /**
-   * Injects code into the specified cell of a notebook, does not run the code.
+   * @description Injects code into the specified cell of a notebook, does not run the code.
    * Warning: the existing cell's code/text will be overwritten.
    * @param notebook The notebook to select the cell from
    * @param index The index of the cell to inject the code into
@@ -287,7 +248,7 @@ namespace cell_utils {
   }
 
   /**
-   * This will insert a new cell at the specified index and the inject the specified code into it.
+   * @description This will insert a new cell at the specified index and the inject the specified code into it.
    * @param command The command registry which can execute the insert command
    * @param notebook The notebook to insert the cell into
    * @param index The index of where the new cell will be inserted.
@@ -296,31 +257,26 @@ namespace cell_utils {
    * @param code The code to inject into the cell after it has been inserted
    * @returns Promise<number> - A promise for when the cell is ready, and at what index it was inserted
    */
-  export function insertInjectCode(
+  export async function insertInjectCode(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number,
     code: string
   ): Promise<number> {
-    let prom: Promise<number> = new Promise((resolve, reject) => {
-      insertCellAtIndex(command, notebook_panel, index)
-        .then(insertionIndex => {
-          try {
-            injectCodeAtIndex(notebook_panel.content, insertionIndex, code);
-            resolve(insertionIndex);
-          } catch (error) {
-            reject(error);
-          }
-        })
-        .catch(error => {
-          reject(error);
-        });
+    let prom: Promise<number> = new Promise(async (resolve, reject) => {
+      try {
+        let newIndex = await insertCellAtIndex(command, notebook_panel, index);
+        injectCodeAtIndex(notebook_panel.content, newIndex, code);
+        resolve(newIndex);
+      } catch (error) {
+        reject(error);
+      }
     });
     return prom;
   }
 
   /**
-   * This will insert a new cell at the specified index, inject the specified code into it and the run the code.
+   * @description This will insert a new cell at the specified index, inject the specified code into it and the run the code.
    * @param command The command registry which can execute the insert command
    * @param notebook_panel The notebook to insert the cell into
    * @param index The index of where the new cell will be inserted and run.
@@ -331,7 +287,7 @@ namespace cell_utils {
    * @returns Promise<[number, string]> - A promise for when the cell code has executed
    * containing the cell's index and output result
    */
-  export function insertAndRun(
+  export async function insertAndRun(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     index: number,
@@ -367,7 +323,9 @@ namespace cell_utils {
   }
 
   /**
-   * This will insert a cell with specified code at the top and run the code.
+   * @deprecated Using notebook_utils.sendSimpleKernelRequest or notebook_utils.sendKernelRequest
+   * will execute code directly in the kernel without the need to create a cell and delete it.
+   * @description This will insert a cell with specified code at the top and run the code.
    * Once the code is run and output received, the cell is deleted, giving back cell's output.
    * If the code results in an error, the injected cell is still deleted but the promise will be rejected.
    * @param command The command registry
@@ -376,30 +334,30 @@ namespace cell_utils {
    * @param insertAtEnd True means the cell will be inserted at the bottom
    * @returns Promise<string> - A promise when the cell has been deleted, containing the execution result as a string
    */
-  export function runAndDelete(
+  export async function runAndDelete(
     command: CommandRegistry,
     notebook_panel: NotebookPanel,
     code: string,
     insertAtEnd = true
   ): Promise<string> {
-    let prom: Promise<string> = new Promise((resolve, reject) => {
+    let prom: Promise<string> = new Promise(async (resolve, reject) => {
       let index: number = -1;
-      if (insertAtEnd) {
-        index = notebook_panel.content.model.cells.length;
+      try {
+        if (insertAtEnd) {
+          index = notebook_panel.content.model.cells.length;
+        }
+        let result: [number, string] = await insertAndRun(
+          command,
+          notebook_panel,
+          index,
+          code,
+          true
+        );
+        await deleteCellAtIndex(command, notebook_panel, result[0]);
+        resolve(result[1]);
+      } catch (error) {
+        reject(error);
       }
-      insertAndRun(command, notebook_panel, index, code, true)
-        .then(result => {
-          deleteCellAtIndex(command, notebook_panel, result[0])
-            .then(() => {
-              resolve(result[1]);
-            })
-            .catch(error => {
-              reject(error);
-            });
-        })
-        .catch(error => {
-          reject(error);
-        });
     });
     return prom;
   }

--- a/src/components/VCSMenu.tsx
+++ b/src/components/VCSMenu.tsx
@@ -21,6 +21,7 @@ export type VCSMenuProps = {
   inject: any; // a method to inject code into the controllers notebook
   file_path: string; // the file path for the selected netCDF file
   commands: any; // the command executor
+  plotReady: boolean;
 };
 type VCSMenuState = {
   file_path: string;
@@ -36,7 +37,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
     super(props);
     this.state = {
       file_path: props.file_path,
-      plotReady: false,
+      plotReady: props.plotReady,
       selected_variables: new Array<Variable>(),
       selected_gm: "",
       selected_gm_group: "",
@@ -107,6 +108,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
     };
     let VarMenuProps = {
       file_path: this.state.file_path,
+      vcs_ready: this.state.plotReady,
       loadVariable: this.updateVarOptions,
       commands: this.props.commands
     };
@@ -127,7 +129,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
               className="col-sm-3"
               style={btnStyle}
               onClick={this.plot}
-              disabled={this.state.plotReady}
+              disabled={!this.state.plotReady}
             >
               Generate Plot
             </Button>
@@ -137,7 +139,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
               className="col-sm-3"
               style={btnStyle}
               onClick={this.plot}
-              disabled={this.state.plotReady}
+              disabled={!this.state.plotReady}
             >
               Save Plot
             </Button>
@@ -147,7 +149,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
               className="col-sm-3"
               style={btnStyle}
               onClick={this.plot}
-              disabled={this.state.plotReady}
+              disabled={!this.state.plotReady}
             >
               Clear Plot
             </Button>

--- a/src/components/VarLoader.tsx
+++ b/src/components/VarLoader.tsx
@@ -8,8 +8,6 @@ import {
   Button,
   Row,
   Col,
-  FormGroup,
-  Input
 } from "reactstrap";
 
 import { DimensionSlider } from "./DimensionSlider";

--- a/src/components/VarMenu.tsx
+++ b/src/components/VarMenu.tsx
@@ -29,6 +29,7 @@ type VarMenuProps = {
   file_path: string; // the path to our file of interest
   loadVariable: any; // a method to call when loading the variable
   commands: any; // the command executer
+  vcs_ready: boolean; // whether notebook is ready for code injection
 };
 
 type VarMenuState = {
@@ -126,7 +127,7 @@ export default class VarMenu extends React.Component<
 
   render() {
     var buttonClicker;
-    if (!this.props.file_path) {
+    if (!this.props.file_path || !this.props.vcs_ready) {
       buttonClicker = this.launchFilebrowser;
     } else {
       buttonClicker = this.toggleMenu;
@@ -138,11 +139,11 @@ export default class VarMenu extends React.Component<
             <CardTitle>Variable Options</CardTitle>
             <CardSubtitle>
               <Button onClick={buttonClicker}>
-                {!this.props.file_path && <span>Load Data</span>}
-                {this.props.file_path && <span>Select Variables</span>}
+                {(!this.props.file_path || !this.props.vcs_ready) && <span>Load Data</span>}
+                {this.props.file_path && this.props.vcs_ready && <span>Select Variables</span>}
               </Button>
             </CardSubtitle>
-            <Collapse isOpen={this.state.showMenu && this.props.file_path!=""}>
+            <Collapse isOpen={this.state.showMenu && this.props.file_path!="" && this.props.vcs_ready}>
               {this.state.variablesFetched && (
                 <Form>
                   {this.state.variables.map(item => {

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,3 +1,9 @@
+const BASE_URL = "/vcs";
+const READY_KEY = "vcdat_ready";
+const FILE_PATH_KEY = "vcdat_file_path";
+const IMPORT_CELL_KEY = "vcdat_imports";
+const REQUIRED_MODULES = "'lazy_import','cdms2','vcs'";
+
 const GET_VARS_CMD =
   'import __main__\n\
 import json\n\
@@ -32,8 +38,6 @@ def variables():\n\
     return out\n\
 output = variables()";
 
-const REQUIRED_MODULES = "'lazy_import','cdms2','vcs'";
-
 const CHECK_MODULES_CMD = `import types\n\
 required = [${REQUIRED_MODULES}]\n\
 def imports():\n\
@@ -43,17 +47,23 @@ def imports():\n\
 found = list(imports())\n\
 output = list(set(required)-set(found))`;
 
-const BASE_URL = "/vcs";
-
-const READY_KEY = "vcdat_ready";
-const FILE_PATH_KEY = "vcdat_file_path";
+const LIST_CANVASES_CMD = `import __main__\n
+def canvases():\n\
+  out = []\n\
+  for nm, obj in __main__.__dict__.items():\n\
+    if isinstance(obj, vcs.Canvas.Canvas):\n\
+      out+=[nm]\n\
+  return out\n\
+output = canvases()`;
 
 export {
+  BASE_URL,
+  READY_KEY,
+  FILE_PATH_KEY,
+  IMPORT_CELL_KEY,
+  REQUIRED_MODULES,
   GET_VARS_CMD,
   REFRESH_VARS_CMD,
   CHECK_MODULES_CMD,
-  REQUIRED_MODULES,
-  BASE_URL,
-  READY_KEY,
-  FILE_PATH_KEY
+  LIST_CANVASES_CMD
 };

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -34,13 +34,14 @@ output = variables()";
 
 const REQUIRED_MODULES = "'lazy_import','cdms2','vcs'";
 
-const CHECK_MODULES_CMD = `import sys\n\
-all_modules = [${REQUIRED_MODULES}]\n\
-output = []\n\
-for module in all_modules:\n\
-	if module not in sys.modules:\n\
-		output.append(module)\n\
-output`;
+const CHECK_MODULES_CMD = `import types\n\
+required = [${REQUIRED_MODULES}]\n\
+def imports():\n\
+  for name, val in globals().items():\n\
+    if isinstance(val, types.ModuleType):\n\
+      yield val.__name__\n\
+found = list(imports())\n\
+output = list(set(required)-set(found))`;
 
 const BASE_URL = "/vcs";
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -20,17 +20,27 @@ def list_all():\n\
     out["gm"] = graphic_methods()\n\
     out["template"] = templates()\n\
     return out\n\
-print("{}|{}|{})".format(variables(),templates(),graphic_methods()))';
+output = "{}|{}|{})".format(variables(),templates(),graphic_methods())';
+
+const REFRESH_VARS_CMD =
+  "import __main__\n\
+def variables():\n\
+    out = []\n\
+    for nm, obj in __main__.__dict__.items():\n\
+        if isinstance(obj, cdms2.MV2.TransientVariable):\n\
+            out+=[nm]\n\
+    return out\n\
+output = variables()";
 
 const REQUIRED_MODULES = "'lazy_import','cdms2','vcs'";
 
 const CHECK_MODULES_CMD = `import sys\n\
 all_modules = [${REQUIRED_MODULES}]\n\
-missed_modules = []\n\
+output = []\n\
 for module in all_modules:\n\
 	if module not in sys.modules:\n\
-		missed_modules.append(module)\n\
-missed_modules`;
+		output.append(module)\n\
+output`;
 
 const BASE_URL = "/vcs";
 
@@ -39,6 +49,7 @@ const FILE_PATH_KEY = "vcdat_file_path";
 
 export {
   GET_VARS_CMD,
+  REFRESH_VARS_CMD,
   CHECK_MODULES_CMD,
   REQUIRED_MODULES,
   BASE_URL,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import "../style/css/index.css";
-import { notebook_utils as nb_utils, notebook_utils } from "./notebook_utils";
+import { notebook_utils as nb_utils } from "./notebook_utils";
 import {
   ABCWidgetFactory,
   DocumentRegistry,
@@ -15,28 +15,15 @@ import {
 
 import { CommandRegistry } from "@phosphor/commands";
 import { NCViewerWidget, LeftSideBarWidget } from "./widgets";
-import {
-  INotebookTracker,
-  NotebookTracker,
-  NotebookPanel,
-  Notebook
-} from "@jupyterlab/notebook";
-import { REFRESH_VARS_CMD } from "./constants";
-import { Cell } from "@jupyterlab/cells";
-import { IClientSession } from "@jupyterlab/apputils";
-import { Kernel } from "@jupyterlab/services";
+import { INotebookTracker, NotebookTracker } from "@jupyterlab/notebook";
 
 const FILETYPE = "NetCDF";
 const FACTORY_NAME = "vcs";
 
 // Declare the widget variables
 let commands: CommandRegistry;
-let nb_tracker: NotebookTracker;
-let nb_panel_current: NotebookPanel; // The current notebook panel targeted by the app
 let sidebar: LeftSideBarWidget; // The sidebar widget of the app
 let shell: ApplicationShell;
-let notebook_active: boolean; // Keeps track whether a notebook is active or not
-let var_refresh: boolean; // If true, it means the vars list should be updated
 
 /**
  * Initialization data for the jupyter-vcdat extension.
@@ -56,7 +43,6 @@ export default extension;
 function activate(app: JupyterLab, tracker: NotebookTracker) {
   commands = app.commands;
   shell = app.shell;
-  nb_tracker = tracker;
 
   const factory = new NCViewerFactory({
     name: FACTORY_NAME,
@@ -83,7 +69,7 @@ function activate(app: JupyterLab, tracker: NotebookTracker) {
   // Creates the left side bar widget once the app has fully started
   app.started.then(() => {
     // Create the left side bar
-    sidebar = new LeftSideBarWidget(commands, nb_tracker);
+    sidebar = new LeftSideBarWidget(commands, tracker);
     sidebar.id = "vcdat-left-side-bar";
     sidebar.title.iconClass = "jp-vcdat-icon jp-SideBar-tabIcon";
     sidebar.title.closable = true;
@@ -95,120 +81,12 @@ function activate(app: JupyterLab, tracker: NotebookTracker) {
     shell.activateById(sidebar.id);
   });
 
-  // Sets the current notebook once the application shell has been restored
+  // Initializes the sidebar widget once the application shell has been restored
   // and all the widgets have been added to the notebooktracker
-  app.shell.restored
-    .then(() => {
-      // Set active true because if there isn't an active notebook, one will be created.
-      notebook_active = true;
-
-      // Activate variable list refresh
-      var_refresh = true;
-
-      // Check the active widget is a notebook panel
-      if (nb_tracker.currentWidget instanceof NotebookPanel) {
-        console.log("Currently open notebook selected.");
-        nb_panel_current = nb_tracker.currentWidget;
-        sidebar.notebook_panel = nb_panel_current;
-        // Track when kernel runs code and becomes idle
-        nb_panel_current.session.statusChanged.connect(handleSessionChanged);
-
-        // Track when active cell is changed in current notebook
-        nb_panel_current.content.activeCellChanged.connect(handleCellChanged);
-
-        // Notebook tracker will signal when a notebook is changed
-        nb_tracker.currentChanged.connect(handleNotebooksChanged);
-      } else {
-        // There is no active notebook widget, so create a new one
-        console.log("Created new notebook at start.");
-        nb_utils
-          .createNewNotebook(commands)
-          .then(notebook => {
-            nb_panel_current = notebook;
-            sidebar.notebook_panel = notebook;
-
-            // Track when kernel runs code and becomes idle
-            nb_panel_current.session.statusChanged.connect(
-              handleSessionChanged
-            );
-
-            // Track when active cell is changed in current notebook
-            nb_panel_current.content.activeCellChanged.connect(
-              handleCellChanged
-            );
-
-            // Notebook tracker will signal when a notebook is changed
-            nb_tracker.currentChanged.connect(handleNotebooksChanged);
-          })
-          .catch(error => {
-            console.log(error);
-          });
-      }
-    })
-    .catch(error => {
-      notebook_active = false;
-      console.log(error);
-    });
+  app.shell.restored.then(() => {
+    sidebar.initialize();
+  });
 }
-
-// Perform actions when current notebook is changed
-async function handleNotebooksChanged(
-  tracker: NotebookTracker,
-  notebook: NotebookPanel
-) {
-  try {
-    if (notebook) {
-      console.log(`Notebook changed to ${notebook.title.label}.`);
-
-      // Disconnect handlers from previous notebook_panel
-      nb_panel_current.session.statusChanged.disconnect(handleSessionChanged);
-      nb_panel_current.content.activeCellChanged.disconnect(handleCellChanged);
-
-      // Update current notebook and status
-      nb_panel_current = notebook;
-      sidebar.notebook_panel = notebook;
-      notebook_active = true;
-
-      // Connect handlers to new notebook
-      nb_panel_current.session.statusChanged.connect(handleSessionChanged);
-      nb_panel_current.content.activeCellChanged.connect(handleCellChanged);
-    } else {
-      console.log("No active notebook detected.");
-      notebook_active = false;
-    }
-  } catch (error) {
-    console.log(error);
-  }
-}
-
-// Performs actions whenever the current notebook session changes status
-async function handleSessionChanged(
-  session: IClientSession,
-  status: Kernel.Status
-) {
-  try {
-    // Don't do anythin unless kernel is idle, the notebook is vcs ready and variables need a refresh
-    if (status == "idle" && sidebar.vcs_ready && var_refresh) {
-      // If the status is idle, vcs is ready and variables need to be refreshed
-      var_refresh = false;
-      //Refresh the variables
-      let output: string = await notebook_utils.sendSimpleKernelRequest(
-        nb_panel_current,
-        REFRESH_VARS_CMD
-      );
-      //Output gives the list of latest variables. This could be added to the
-      console.log(output);
-    } else if (status == "idle" && sidebar.vcs_ready) {
-      var_refresh = true;
-    }
-  } catch (error) {
-    console.log(error);
-    var_refresh = false;
-  }
-}
-
-// Perform actions when active cell is changed in current notebook
-async function handleCellChanged(notebook: Notebook, cell: Cell) {}
 
 /**
  * Create a new widget given a context.
@@ -230,13 +108,10 @@ export class NCViewerFactory extends ABCWidgetFactory<
       sidebar.current_file = context.session.name;
 
       // Check if there's an open notebook
-      if (notebook_active) {
+      if (sidebar.notebook_active) {
         // Activate the notebook panel if it's not active
-        if (shell.activeWidget == nb_panel_current) {
-          // Update current notebook to be the active notebook
-          sidebar.notebook_panel = nb_panel_current;
-        } else {
-          shell.activateById(nb_panel_current.id);
+        if (shell.activeWidget != sidebar.notebook_panel) {
+          shell.activateById(sidebar.notebook_panel.id);
         }
 
         // Prepare the notebook for code injection

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,3 @@
-import "../style/css/index.css";
-import { notebook_utils as nb_utils } from "./notebook_utils";
 import {
   ABCWidgetFactory,
   DocumentRegistry,
@@ -16,6 +14,9 @@ import {
 import { CommandRegistry } from "@phosphor/commands";
 import { NCViewerWidget, LeftSideBarWidget } from "./widgets";
 import { INotebookTracker, NotebookTracker } from "@jupyterlab/notebook";
+
+import "../style/css/index.css";
+import { notebook_utils as nb_utils } from "./notebook_utils";
 
 const FILETYPE = "NetCDF";
 const FACTORY_NAME = "vcs";

--- a/src/notebook_utils.ts
+++ b/src/notebook_utils.ts
@@ -7,7 +7,7 @@ namespace notebook_utils {
   /**
    * @description Creates a new JupyterLab notebook for use by the application
    * @param command The command registry
-   * @returns A promise containing the notebook panel object that was created (if successful).
+   * @returns Promise<NotebookPanel> - A promise containing the notebook panel object that was created (if successful).
    */
   export async function createNewNotebook(
     command: CommandRegistry
@@ -29,11 +29,11 @@ namespace notebook_utils {
   }
 
   /**
-   * @description Gets the value of a key from specified notebook's metadata. Returns null if the key doesn't exist.
-   * Checks the notebook session is ready before getting the metadata.
+   * @description Gets the value of a key from specified notebook's metadata.
+   * This asynchronous version checks the notebook session is ready before getting metadata.
    * @param notebook_panel The notebook to get meta data from.
    * @param key The key of the value.
-   * @returns The value of the metadata.
+   * @returns any - The value of the metadata. Returns null if the key doesn't exist.
    */
   export async function getMetaData(
     notebook_panel: NotebookPanel,
@@ -45,7 +45,7 @@ namespace notebook_utils {
         if (notebook_panel.content.model.metadata.has(key)) {
           resolve(notebook_panel.content.model.metadata.get(key));
         } else {
-          return resolve(null);
+          resolve(null);
         }
       } catch (error) {
         reject(error);
@@ -55,8 +55,29 @@ namespace notebook_utils {
   }
 
   /**
+   * @description Gets the value of a key from specified notebook's metadata.
+   * @param notebook_panel The notebook to get meta data from.
+   * @param key The key of the value.
+   * @returns any -The value of the metadata. Returns null if the key doesn't exist.
+   */
+  export function getMetaDataNow(
+    notebook_panel: NotebookPanel,
+    key: string
+  ): any {
+    try {
+      if (notebook_panel.content.model.metadata.has(key)) {
+        return notebook_panel.content.model.metadata.get(key);
+      } else {
+        return null;
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
    * @description Sets the key value pair in the notebook's metadata. If the key doesn't exists it will add one.
-   * Checks the notebook session is ready before getting the metadata.
+   * This asynchronous version checks the notebook session is ready before setting the metadata.
    * @param notebook_panel The notebook to set meta data in.
    * @param key The key of the value to create.
    * @param value The value to set.
@@ -76,6 +97,26 @@ namespace notebook_utils {
       }
     });
     return prom;
+  }
+
+  /**
+   * @description Sets the key value pair in the notebook's metadata.
+   * If the key doesn't exists it will add one.
+   * @param notebook_panel The notebook to set meta data in.
+   * @param key The key of the value to create.
+   * @param value The value to set.
+   * @returns The old value for the key, or undefined if it did not exist.
+   */
+  export function setMetaDataNow(
+    notebook_panel: NotebookPanel,
+    key: string,
+    value: any
+  ): any {
+    try {
+      return notebook_panel.content.model.metadata.set(key, value);
+    } catch (error) {
+      throw error;
+    }
   }
 
   /**

--- a/src/notebook_utils.ts
+++ b/src/notebook_utils.ts
@@ -105,8 +105,11 @@ namespace notebook_utils {
           let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
             {
               code: code,
+              silent: false,
+              store_history: store_history,
               user_expressions: { result: "output" },
-              store_history: store_history
+              allow_stdin: false,
+              stop_on_error: false
             }
           ).done;
           let content: any = message.content;
@@ -139,8 +142,14 @@ namespace notebook_utils {
    * @param notebook_panel The notebook to run the code in.
    * @param code The code to run in the kernel.
    * @param user_expressions The expressions used to capture the desired info from the executed code.
+   * @param silent Default is false. If true, kernel will execute as quietly as possible.
+   * store_history will be set to false, and no broadcast on IOPUB channel will be made.
    * @param store_history Default is false. If true, the code executed will be stored in the kernel's history
    * and the counter which is shown in the cells will be incremented to reflect code was run.
+   * @param allow_stdin Default is false. If true, code running in kernel can prompt user for input using
+   * an input_request message.
+   * @param stop_on_error Default is false. If True, does not abort the execution queue, if an exception is encountered.
+   * This allows the queued execution of multiple execute_requests, even if they generate exceptions.
    * @returns Promise<any> - A promise containing the execution results of the code as an object with
    * keys based on the user_expressions.
    * @example
@@ -163,7 +172,10 @@ namespace notebook_utils {
     notebook_panel: NotebookPanel,
     code: string,
     user_expressions: any,
-    store_history: boolean = false
+    silent: boolean = false,
+    store_history: boolean = false,
+    allow_stdin: boolean = false,
+    stop_on_error: boolean = false
   ): Promise<any> {
     let prom: Promise<any> = new Promise(async (resolve, reject) => {
       // Check notebook panel is ready
@@ -175,8 +187,11 @@ namespace notebook_utils {
           let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
             {
               code: code,
+              silent: silent,
+              store_history: store_history,
               user_expressions: user_expressions,
-              store_history: store_history
+              allow_stdin: allow_stdin,
+              stop_on_error: stop_on_error
             }
           ).done;
           let content: any = message.content;

--- a/src/notebook_utils.ts
+++ b/src/notebook_utils.ts
@@ -81,17 +81,28 @@ namespace notebook_utils {
    * @param notebook_panel The notebook to set meta data in.
    * @param key The key of the value to create.
    * @param value The value to set.
+   * @param save Default is false. Whether the notebook should be saved after the meta data is set.
    * @returns The old value for the key, or undefined if it did not exist.
    */
   export function setMetaData(
     notebook_panel: NotebookPanel,
     key: string,
-    value: any
+    value: any,
+    save: boolean = false
   ): Promise<any> {
     let prom: Promise<any> = new Promise(async (resolve, reject) => {
       try {
         await notebook_panel.session.ready;
-        resolve(notebook_panel.content.model.metadata.set(key, value));
+        let old_val: any = notebook_panel.content.model.metadata.set(
+          key,
+          value
+        );
+        if (save) {
+          await notebook_panel.context.save().catch(error => {
+            reject(error);
+          });
+        }
+        resolve(old_val);
       } catch (error) {
         reject(error);
       }
@@ -105,15 +116,24 @@ namespace notebook_utils {
    * @param notebook_panel The notebook to set meta data in.
    * @param key The key of the value to create.
    * @param value The value to set.
+   * @param save Default is false. Whether the notebook should be saved after the meta data is set.
+   * Note: This function will not wait for the save to complete, it only sends a save request.
    * @returns The old value for the key, or undefined if it did not exist.
    */
   export function setMetaDataNow(
     notebook_panel: NotebookPanel,
     key: string,
-    value: any
+    value: any,
+    save: boolean = false
   ): any {
     try {
-      return notebook_panel.content.model.metadata.set(key, value);
+      let old_val = notebook_panel.content.model.metadata.set(key, value);
+      if (save) {
+        notebook_panel.context.save().catch(error => {
+          throw error;
+        });
+      }
+      return old_val;
     } catch (error) {
       throw error;
     }

--- a/src/notebook_utils.ts
+++ b/src/notebook_utils.ts
@@ -1,63 +1,61 @@
-import { Notebook, NotebookPanel } from "@jupyterlab/notebook";
+import { NotebookPanel } from "@jupyterlab/notebook";
 import { CommandRegistry } from "@phosphor/commands";
+import { KernelMessage } from "@jupyterlab/services";
 
 /** Contains utility functions for manipulating/handling notebooks in the application. */
 namespace notebook_utils {
   /**
-   * Creates a new JupyterLab notebook for use by the application
+   * @description Creates a new JupyterLab notebook for use by the application
    * @param command The command registry
    * @returns A promise containing the notebook panel object that was created (if successful).
    */
-  export function createNewNotebook(
+  export async function createNewNotebook(
     command: CommandRegistry
   ): Promise<NotebookPanel> {
-    let prom: Promise<NotebookPanel> = new Promise((resolve, reject) => {
-      command
-        .execute("notebook:create-new", {
+    let prom: Promise<NotebookPanel> = new Promise(async (resolve, reject) => {
+      try {
+        let notebook: any = await command.execute("notebook:create-new", {
           activate: true,
           path: "",
           preferredLanguage: ""
-        })
-        .then(notebook => {
-          notebook.session.ready.then(() => {
-            resolve(notebook);
-          });
-        })
-        .catch(error => {
-          reject(error);
         });
+        await notebook.session.ready;
+        resolve(notebook);
+      } catch (error) {
+        reject(error);
+      }
     });
     return prom;
   }
 
   /**
-   * Gets the value of a key from specified notebook's metadata. Returns null if the key doesn't exist.
+   * @description Gets the value of a key from specified notebook's metadata. Returns null if the key doesn't exist.
    * Checks the notebook session is ready before getting the metadata.
    * @param notebook_panel The notebook to get meta data from.
    * @param key The key of the value.
    * @returns The value of the metadata.
    */
-  export function getMetaData(
+  export async function getMetaData(
     notebook_panel: NotebookPanel,
     key: string
   ): Promise<any> {
-    return new Promise((resolve, reject) => {
-      notebook_panel.session.ready
-        .then(() => {
-          if (notebook_panel.content.model.metadata.has(key)) {
-            resolve(notebook_panel.content.model.metadata.get(key));
-          } else {
-            return resolve(null);
-          }
-        })
-        .catch(error => {
-          reject(error);
-        });
+    let prom: Promise<any> = new Promise(async (resolve, reject) => {
+      try {
+        await notebook_panel.session.ready;
+        if (notebook_panel.content.model.metadata.has(key)) {
+          resolve(notebook_panel.content.model.metadata.get(key));
+        } else {
+          return resolve(null);
+        }
+      } catch (error) {
+        reject(error);
+      }
     });
+    return prom;
   }
 
   /**
-   * Sets the key value pair in the notebook's metadata. If the key doesn't exists it will add one.
+   * @description Sets the key value pair in the notebook's metadata. If the key doesn't exists it will add one.
    * Checks the notebook session is ready before getting the metadata.
    * @param notebook_panel The notebook to set meta data in.
    * @param key The key of the value to create.
@@ -69,15 +67,132 @@ namespace notebook_utils {
     key: string,
     value: any
   ): Promise<any> {
-    return new Promise((resolve, reject) => {
-      notebook_panel.session.ready
-        .then(() => {
-          resolve(notebook_panel.content.model.metadata.set(key, value));
-        })
-        .catch(error => {
-          reject(error);
-        });
+    let prom: Promise<any> = new Promise(async (resolve, reject) => {
+      try {
+        await notebook_panel.session.ready;
+        resolve(notebook_panel.content.model.metadata.set(key, value));
+      } catch (error) {
+        reject(error);
+      }
     });
+    return prom;
+  }
+
+  /**
+   * @description This function runs code directly in the notebook's kernel and then evaluates the
+   * result and returns it as a promise.
+   * @param notebook_panel The notebook to run the code in
+   * @param code The code to run in the kernel, this code needs to evaluate to a variable named 'output'
+   * Examples of valid code:
+   *  Single line: "output=123+456"
+   *  Multilines: "a = [1,2,3]\nb = [4,5,6]\nfor idx, val in enumerate(a):\n\tb[idx]+=val\noutput = b"
+   * @param store_history Default is false. If true, the code executed will be stored in the kernel's history
+   * and the counter which is shown in the cells will be incremented to reflect code was run.
+   * @returns Promise<string> - A promise containing the execution results of the code as a string.
+   */
+  export async function sendSimpleKernelRequest(
+    notebook_panel: NotebookPanel,
+    code: string,
+    store_history: boolean = false
+  ): Promise<string> {
+    let prom: Promise<string> = new Promise(async (resolve, reject) => {
+      // Check notebook panel is ready
+      if (notebook_panel) {
+        try {
+          // Wait for kernel to be ready before sending request
+          await notebook_panel.session.ready;
+          await notebook_panel.session.kernel.ready;
+          let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
+            {
+              code: code,
+              user_expressions: { result: "output" },
+              store_history: store_history
+            }
+          ).done;
+          let content: any = message.content;
+          if (content["status"] == "ok") {
+            let output = content["user_expressions"]["result"];
+            if (output) {
+              //Output has data
+              let execResult: string = output["data"]["text/plain"];
+              resolve(execResult);
+            } else {
+              //Output was empty
+              resolve("");
+            }
+          } else {
+            reject(content);
+          }
+        } catch (error) {
+          reject(error);
+        }
+      } else {
+        reject(new Error("The notebook panel is null or undefined."));
+      }
+    });
+    return prom;
+  }
+
+  /**
+   * @description This function runs code directly in the notebook's kernel and then evaluates the
+   * result and returns it as a promise.
+   * @param notebook_panel The notebook to run the code in.
+   * @param code The code to run in the kernel.
+   * @param user_expressions The expressions used to capture the desired info from the executed code.
+   * @param store_history Default is false. If true, the code executed will be stored in the kernel's history
+   * and the counter which is shown in the cells will be incremented to reflect code was run.
+   * @returns Promise<any> - A promise containing the execution results of the code as an object with
+   * keys based on the user_expressions.
+   * @example
+   * //The code
+   * const code = "a=123\nb=456\nsum=a+b";
+   * //The user expressions
+   * const expr = {sum: "sum",prod: "a*b",args:"[a,b,sum]"};
+   * //Async function call (returns a promise)
+   * sendKernelRequest(notebook_panel, code, expr,false);
+   * //Result when promise resolves:
+   * {
+   *  sum:{status:"ok",data:{"text/plain":"579"},metadata:{}},
+   *  prod:{status:"ok",data:{"text/plain":"56088"},metadata:{}},
+   *  args:{status:"ok",data:{"text/plain":"[123, 456, 579]"}}
+   * }
+   * @see For more information on JupyterLab messages:
+   * https://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-results
+   */
+  export async function sendKernelRequest(
+    notebook_panel: NotebookPanel,
+    code: string,
+    user_expressions: any,
+    store_history: boolean = false
+  ): Promise<any> {
+    let prom: Promise<any> = new Promise(async (resolve, reject) => {
+      // Check notebook panel is ready
+      if (notebook_panel) {
+        try {
+          // Wait for kernel to be ready before sending request
+          await notebook_panel.session.ready;
+          await notebook_panel.session.kernel.ready;
+          let message: KernelMessage.IShellMessage = await notebook_panel.session.kernel.requestExecute(
+            {
+              code: code,
+              user_expressions: user_expressions,
+              store_history: store_history
+            }
+          ).done;
+          let content: any = message.content;
+          if (content["status"] == "ok") {
+            resolve(content.user_expressions);
+          } else {
+            reject(content);
+          }
+        } catch (error) {
+          reject(error);
+        }
+      } else {
+        reject(new Error("The notebook panel is null or undefined."));
+      }
+    });
+    return prom;
   }
 }
 

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { notebook_utils as nb_utils, notebook_utils } from "./notebook_utils";
-import { cell_utils } from "./cell_utils";
 import { Widget } from "@phosphor/widgets";
 import { VCSMenu } from "./components/VCSMenu";
 import { CommandRegistry } from "@phosphor/commands";
 import { DocumentRegistry } from "@jupyterlab/docregistry";
+import { NotebookTracker, NotebookPanel } from "@jupyterlab/notebook";
+import { IClientSession } from "@jupyterlab/apputils";
+import { Kernel } from "@jupyterlab/services";
+
 import {
   GET_VARS_CMD,
   CHECK_MODULES_CMD,
@@ -13,9 +15,8 @@ import {
   FILE_PATH_KEY,
   REFRESH_VARS_CMD
 } from "./constants";
-import { NotebookTracker, NotebookPanel } from "@jupyterlab/notebook";
-import { IClientSession } from "@jupyterlab/apputils";
-import { Kernel } from "@jupyterlab/services";
+import { notebook_utils as nb_utils } from "./notebook_utils";
+import { cell_utils } from "./cell_utils";
 
 export class LeftSideBarWidget extends Widget {
   div: HTMLDivElement; // The div container for this widget
@@ -176,7 +177,7 @@ export class LeftSideBarWidget extends Widget {
         // If the status is idle, vcs is ready and variables need to be refreshed
         this.var_refresh = false;
         //Refresh the variables
-        let output: string = await notebook_utils.sendSimpleKernelRequest(
+        let output: string = await nb_utils.sendSimpleKernelRequest(
           this.notebook_panel,
           REFRESH_VARS_CMD
         );
@@ -283,7 +284,7 @@ export class LeftSideBarWidget extends Widget {
 
       if (find[0] >= 0) {
         // If found, run the imports code
-        await notebook_utils.sendSimpleKernelRequest(
+        await nb_utils.sendSimpleKernelRequest(
           this.notebook_panel,
           find[1].value.text,
           false
@@ -333,7 +334,7 @@ export class LeftSideBarWidget extends Widget {
     var prom: Promise<number> = new Promise(async (resolve, reject) => {
       try {
         // Check if necessary modules are loaded
-        let output: string = await notebook_utils.sendSimpleKernelRequest(
+        let output: string = await nb_utils.sendSimpleKernelRequest(
           this.notebook_panel,
           CHECK_MODULES_CMD
         );
@@ -423,7 +424,7 @@ export class LeftSideBarWidget extends Widget {
   async updateVars() {
     try {
       let notebook_panel: NotebookPanel = await this.getReadyNotebookPanel();
-      let output: string = await notebook_utils.sendSimpleKernelRequest(
+      let output: string = await nb_utils.sendSimpleKernelRequest(
         notebook_panel,
         GET_VARS_CMD
       );


### PR DESCRIPTION
Made some significant updates to the cell_utils and notebook_utils modules:
- Some functions have been changed from being asynchronous to synchronous, also by utilizing the ability to run code directly on kernel, I removed the dependency that some functions had on a command registry. 
- Functions should be simpler to run and require less parameters. Also minor updates to style and commenting of library functions.

- New functions added to allow the tracking of the notebook cells such as those containing vcdat related code, so that we can be sure they are ready before performing any code injection operations. The tracking of the cells is done by setting metadata fo the cell, so the necessary functions have been added to the cell_utils module.

Another major change is that sidebar widget related logic, functions and handlers have been moved from the index.tsx to the widgets.tsx file to hopefully improve separation of concerns. Before the change, I was having to modify both the index and widgets files just to update sidebar related features.

Finally, I made some adjustments to help prevent errors related to a notebook not having it's meta data saved. When a notebook has the import cell added and becomes 'vcs_ready' it will be saved so that a kernel restart, or browser refresh won't break things.