### PR TITLE
Recognize vcs without metadata

### DIFF
--- a/src/components/DimensionSlider.tsx
+++ b/src/components/DimensionSlider.tsx
@@ -135,20 +135,19 @@ export default class DimensionSlider extends React.Component<
     this.domain = [0, lastIdx];
 
     // Set initial selected range
-    let initialMinMax: [number, number] = [0, lastIdx];
-    let idx: number = pValues.indexOf(this.props.min);
-    if (idx > 0) {
-      initialMinMax[0] = idx;
+    let idxMin: number = pValues.indexOf(this.props.min);
+    let idxMax: number = pValues.indexOf(this.props.max);
+    if (idxMin < 0) {
+      idxMin = 0;
     }
-    idx = pValues.indexOf(this.props.max);
-    if (idx > 0) {
-      initialMinMax[1] = idx;
+    if (idxMax < 0) {
+      idxMax = lastIdx;
     }
 
     // Update initial state
     this.state = {
-      min: initialMinMax[0],
-      max: initialMinMax[1],
+      min: idxMin,
+      max: idxMax,
       possibleValues: pValues,
       tickValues: tickVals
     };

--- a/src/components/GraphicsMenu.tsx
+++ b/src/components/GraphicsMenu.tsx
@@ -33,6 +33,7 @@ const listItemStyle: React.CSSProperties = {
 };
 
 interface GraphicsMenuProps {
+  plotReady: boolean;
   getGraphicsList: Function; // a method that gets the current list of graphics methods
   updateGraphicsOptions: Function; // a method to call when the user has selected their desired graphics method
   copyGraphicsMethod: Function; // a method that will create a copy of the currently selected graphics method.
@@ -65,7 +66,7 @@ export default class GraphicsMenu extends React.Component<
       enterName: false,
       nameValue: "",
       invalidName: false,
-      plotReady: false
+      plotReady: this.props.plotReady
     };
     this.handleNameInput = this.handleNameInput.bind(this);
     this.toggleDropdown = this.toggleDropdown.bind(this);

--- a/src/components/TemplateMenu.tsx
+++ b/src/components/TemplateMenu.tsx
@@ -17,6 +17,7 @@ const dropdownMenuStype: React.CSSProperties = {
 };
 
 interface TemplateMenuProps {
+  plotReady: boolean;
   getTemplatesList: Function; // a method to call when the user has seleted a template
   updateTemplateOptions: Function;
 }
@@ -39,7 +40,7 @@ export default class TemplateMenu extends React.Component<
       showDropdown: false,
       selectedTemplate: "",
       optionsChanged: false,
-      plotReady: false
+      plotReady: this.props.plotReady
     };
     this.toggleMenu = this.toggleMenu.bind(this);
     this.toggleDropdown = this.toggleDropdown.bind(this);

--- a/src/components/VCSMenu.tsx
+++ b/src/components/VCSMenu.tsx
@@ -14,6 +14,7 @@ import {
 } from "reactstrap";
 
 // Project Components
+import Container from "reactstrap/lib/Container";
 import {
   CANVAS_DIMENSIONS_CMD,
   GRAPHICS_METHOD_KEY,
@@ -40,7 +41,7 @@ const centered: React.CSSProperties = {
 
 const sidebarOverflow: React.CSSProperties = {
   maxHeight: "100vh",
-  minWidth: "320px",
+  minWidth: "360px",
   overflow: "auto"
 };
 
@@ -62,6 +63,7 @@ export interface VCSMenuProps {
   getFileVariables: Function; // Function that reads the current notebook file and retrieves variable data
   updateVariables: Function; // function that updates the variables list in the main widget
   updateNotebookPanel: Function; // Function passed to the var menu
+  syncNotebook: Function; // Function passed to the var menu
 }
 interface VCSMenuState {
   plotReady: boolean; // are we ready to plot
@@ -426,7 +428,6 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
 
   public updatePlotReady(value: boolean): void {
     this.setState({ plotReady: value });
-    this.varMenuRef.setState({ plotReady: value });
     this.graphicsMenuRef.setState({ plotReady: value });
     this.templateMenuRef.setState({ plotReady: value });
   }
@@ -531,7 +532,6 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
       varInfo: new Variable()
     };
     const VarMenuProps = {
-      plotReady: this.state.plotReady,
       commands: this.props.commands,
       loadVariable: this.loadVariable,
       variables: this.state.variables,
@@ -539,6 +539,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
       updateVariables: this.updateVariables,
       updateSelectedVariables: this.updateSelectedVariables,
       saveNotebook: this.saveNotebook,
+      syncNotebook: this.props.syncNotebook,
       updateNotebook: this.props.updateNotebookPanel
     };
     const TemplateMenuProps = {
@@ -561,35 +562,38 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
           <CardBody>
             <div style={centered}>
               <Row>
-                <Col>
+                <Col sm={3}>
                   <Button
                     type="button"
                     color="primary"
                     style={btnStyle}
                     onClick={this.plot}
                     disabled={!this.state.plotReady}
+                    title="Plot the current selected variable(s)."
                   >
                     Plot
                   </Button>
                 </Col>
-                <Col>
+                <Col sm={5} style={{ padding: "0 5px" }}>
                   <Button
                     type="button"
                     color="primary"
                     style={btnStyle}
                     onClick={this.toggleModal}
                     disabled={!this.state.plotReady || !this.state.plotExists}
+                    title="Exports the current canvas plot."
                   >
-                    Save
+                    Export Plot
                   </Button>
                 </Col>
-                <Col>
+                <Col sm={4}>
                   <Button
                     type="button"
                     color="primary"
                     style={btnStyle}
                     onClick={this.clear}
                     disabled={!this.state.plotReady}
+                    title="Clears the canvas."
                   >
                     Clear
                   </Button>

--- a/src/components/VCSMenu.tsx
+++ b/src/components/VCSMenu.tsx
@@ -61,6 +61,7 @@ export interface VCSMenuProps {
   getTemplatesList: Function; // function that reads the widget's current template list
   getFileVariables: Function; // Function that reads the current notebook file and retrieves variable data
   updateVariables: Function; // function that updates the variables list in the main widget
+  updateNotebookPanel: Function; // Function passed to the var menu
 }
 interface VCSMenuState {
   plotReady: boolean; // are we ready to plot
@@ -425,6 +426,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
 
   public updatePlotReady(value: boolean): void {
     this.setState({ plotReady: value });
+    this.varMenuRef.setState({ plotReady: value });
     this.graphicsMenuRef.setState({ plotReady: value });
     this.templateMenuRef.setState({ plotReady: value });
   }
@@ -522,20 +524,22 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
 
   public render(): JSX.Element {
     const GraphicsMenuProps = {
+      plotReady: this.state.plotReady,
       getGraphicsList: this.props.getGraphicsList,
       updateGraphicsOptions: this.updateGraphicsOptions,
       copyGraphicsMethod: this.copyGraphicsMethod,
-      varInfo: new Variable(),
-      plotReady: this.state.plotReady
+      varInfo: new Variable()
     };
     const VarMenuProps = {
+      plotReady: this.state.plotReady,
       commands: this.props.commands,
       loadVariable: this.loadVariable,
       variables: this.state.variables,
       selectedVariables: this.state.selectedVariables,
       updateVariables: this.updateVariables,
       updateSelectedVariables: this.updateSelectedVariables,
-      saveNotebook: this.saveNotebook
+      saveNotebook: this.saveNotebook,
+      updateNotebook: this.props.updateNotebookPanel
     };
     const TemplateMenuProps = {
       plotReady: this.state.plotReady,
@@ -596,6 +600,7 @@ export class VCSMenu extends React.Component<VCSMenuProps, VCSMenuState> {
                 id="overlayModeSwitch"
                 name="overlayModeSwitch"
                 label="Overlay Mode"
+                disabled={!this.state.plotReady}
                 checked={this.state.overlayMode}
                 onChange={this.toggleOverlayMode}
               />

--- a/src/components/VarMenu.tsx
+++ b/src/components/VarMenu.tsx
@@ -29,7 +29,6 @@ const formOverflow: React.CSSProperties = {
 };
 
 interface VarMenuProps {
-  plotReady: boolean;
   loadVariable: Function; // a method to call when loading the variable
   commands?: any; // the command executer
   variables: Variable[]; // an array of all current variables
@@ -38,10 +37,10 @@ interface VarMenuProps {
   updateVariables: Function; // update the list of all variables
   saveNotebook: Function; // function that saves the current notebook
   updateNotebook: Function; // Updates the current notebook to check if it is vcdat ready
+  syncNotebook: Function; // Function that check if the Notebook should be synced/prepared
 }
 
 interface VarMenuState {
-  plotReady: boolean;
   variables: Variable[]; // all variables for list (derived and loaded)
   selectedVariables: string[]; // the names of the variables the user has selected
 }
@@ -54,7 +53,6 @@ export default class VarMenu extends React.Component<
   constructor(props: VarMenuProps) {
     super(props);
     this.state = {
-      plotReady: this.props.plotReady,
       selectedVariables: this.props.selectedVariables,
       variables: this.props.variables
     };
@@ -210,6 +208,8 @@ export default class VarMenu extends React.Component<
       "#28a745",
       "#17a2b8"
     );
+    const syncNotebook: boolean = this.props.syncNotebook();
+
     return (
       <div>
         <Card>
@@ -217,25 +217,27 @@ export default class VarMenu extends React.Component<
             <CardTitle>Variable Options</CardTitle>
             <CardSubtitle>
               <Row>
-                <Col>
+                <Col sm={6}>
                   <Button
                     color="info"
                     onClick={this.launchFilebrowser}
                     style={varButtonStyle}
+                    title="Load variables from a data file."
                   >
-                    Load Variables
+                    Load Variable(s)
                   </Button>
                 </Col>
-                <Col>
+                <Col sm={6}>
                   <Button
                     color="info"
                     onClick={async () => {
-                      await this.props.updateNotebook();
+                      this.props.updateNotebook();
                     }}
-                    hidden={this.state.plotReady}
+                    hidden={!syncNotebook}
                     style={varButtonStyle}
+                    title="Prepare and synchronize the currently open notebook for use with vCDAT 2.0"
                   >
-                    Update
+                    Sync Notebook
                   </Button>
                 </Col>
               </Row>

--- a/src/components/VarMenu.tsx
+++ b/src/components/VarMenu.tsx
@@ -29,6 +29,7 @@ const formOverflow: React.CSSProperties = {
 };
 
 interface VarMenuProps {
+  plotReady: boolean;
   loadVariable: Function; // a method to call when loading the variable
   commands?: any; // the command executer
   variables: Variable[]; // an array of all current variables
@@ -36,9 +37,11 @@ interface VarMenuProps {
   updateSelectedVariables: Function; // update the list of selected variables
   updateVariables: Function; // update the list of all variables
   saveNotebook: Function; // function that saves the current notebook
+  updateNotebook: Function; // Updates the current notebook to check if it is vcdat ready
 }
 
 interface VarMenuState {
+  plotReady: boolean;
   variables: Variable[]; // all variables for list (derived and loaded)
   selectedVariables: string[]; // the names of the variables the user has selected
 }
@@ -51,6 +54,7 @@ export default class VarMenu extends React.Component<
   constructor(props: VarMenuProps) {
     super(props);
     this.state = {
+      plotReady: this.props.plotReady,
       selectedVariables: this.props.selectedVariables,
       variables: this.props.variables
     };
@@ -220,6 +224,18 @@ export default class VarMenu extends React.Component<
                     style={varButtonStyle}
                   >
                     Load Variables
+                  </Button>
+                </Col>
+                <Col>
+                  <Button
+                    color="info"
+                    onClick={async () => {
+                      await this.props.updateNotebook();
+                    }}
+                    hidden={this.state.plotReady}
+                    style={varButtonStyle}
+                  >
+                    Update
                   </Button>
                 </Col>
               </Row>

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -23,7 +23,7 @@ const VARIABLE_SOURCES_KEY: string = "variable_source_names";
 const GRAPHICS_METHOD_KEY: string = "graphics_method_selected";
 const TEMPLATE_KEY: string = "template_selected";
 const VARIABLES_LOADED_KEY: string = "vcdat_loaded_variables";
-const REQUIRED_MODULES: string = "'lazy_import','cdms2','vcs','sidecar'";
+const REQUIRED_MODULES: string = "'cdms2','vcs','sidecar'";
 
 const CANVAS_DIMENSIONS_CMD: string = `${OUTPUT_RESULT_NAME}=[canvas.width,canvas.height]`;
 

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -27,6 +27,12 @@ const REQUIRED_MODULES: string = "'lazy_import','cdms2','vcs','sidecar'";
 
 const CANVAS_DIMENSIONS_CMD: string = `${OUTPUT_RESULT_NAME}=[canvas.width,canvas.height]`;
 
+const CHECK_VCS_CMD: string = `try:\n\
+  vcs.init()\n\
+  ${OUTPUT_RESULT_NAME}=True\n\
+except:\n\
+  ${OUTPUT_RESULT_NAME}=False\n`;
+
 const GET_VARS_CMD: string = `import __main__\n\
 import json\n\
 def variables():\n\
@@ -80,7 +86,7 @@ def imports():\n\
 found = list(imports())\n\
 ${OUTPUT_RESULT_NAME} = list(set(required)-set(found))`;
 
-const LIST_CANVASES_CMD: string = `import __main__\n
+const LIST_CANVASES_CMD: string = `import __main__\n\
 def canvases():\n\
   out = []\n\
   for nm, obj in __main__.__dict__.items():\n\
@@ -444,6 +450,7 @@ export {
   VARIABLE_SOURCES_KEY,
   REQUIRED_MODULES,
   CANVAS_DIMENSIONS_CMD,
+  CHECK_VCS_CMD,
   GET_VARS_CMD,
   BASE_GRAPHICS,
   BASE_TEMPLATES,

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -27,9 +27,12 @@ const REQUIRED_MODULES: string = "'lazy_import','cdms2','vcs','sidecar'";
 
 const CANVAS_DIMENSIONS_CMD: string = `${OUTPUT_RESULT_NAME}=[canvas.width,canvas.height]`;
 
-const CHECK_VCS_CMD: string = `try:\n\
-  vcs.init()\n\
-  ${OUTPUT_RESULT_NAME}=True\n\
+const CHECK_VCS_CMD: string = `import __main__\n\
+try:\n\
+  for nm, obj in __main__.__dict__.items():\n\
+    if isinstance(obj, cdms2.MV2.TransientVariable):\n\
+      ${OUTPUT_RESULT_NAME}=True\n\
+      break\n\
 except:\n\
   ${OUTPUT_RESULT_NAME}=False\n`;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -99,6 +99,8 @@ function activate(
     );
     sidebar.initialize();
   });
+
+  
 }
 
 // Adds a reference link to the help menu in JupyterLab

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -527,9 +527,12 @@ export class LeftSideBarWidget extends Widget {
     let currentIdx: number = this.notebookPanel.content.model.cells.length - 1;
     await this.injectImportsCode(currentIdx, true);
 
-    // Inject canvas(es)
-    currentIdx = this.notebookPanel.content.model.cells.length - 1;
-    await this.injectCanvasCode(currentIdx, 1);
+    // Inject canvas if needed
+    const canvasExists: boolean = await this.checkCanvasExists();
+    if (!canvasExists) {
+      currentIdx = this.notebookPanel.content.model.cells.length - 1;
+      await this.injectCanvasCode(currentIdx, 1);
+    }
 
     this.state = NOTEBOOK_STATE.VCS_Ready;
 
@@ -574,6 +577,21 @@ export class LeftSideBarWidget extends Widget {
       return true;
     }
     return false;
+  }
+
+  public async checkCanvasExists(): Promise<boolean> {
+    try {
+      // Get the list of display elements in the canvas
+      this.usingKernel = true;
+      const output: string = await NotebookUtilities.sendSimpleKernelRequest(
+        this.notebookPanel,
+        `${OUTPUT_RESULT_NAME} = canvas.listelements('display')`
+      );
+      this.usingKernel = false;
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 
   public async checkPlotExists(): Promise<boolean> {

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -525,10 +525,11 @@ export class LeftSideBarWidget extends Widget {
 
     // Inject the imports
     let currentIdx: number = this.notebookPanel.content.model.cells.length - 1;
-    currentIdx = await this.injectImportsCode(currentIdx, true);
+    await this.injectImportsCode(currentIdx, true);
 
     // Inject canvas(es)
-    currentIdx = await this.injectCanvasCode(currentIdx + 1, 1);
+    currentIdx = this.notebookPanel.content.model.cells.length - 1;
+    await this.injectCanvasCode(currentIdx, 1);
 
     this.state = NOTEBOOK_STATE.VCS_Ready;
 
@@ -841,11 +842,6 @@ export class LeftSideBarWidget extends Widget {
               this.notebookPanel,
               IMPORT_CELL_KEY
             )[0];
-            // Search for a cell containing the data variables key
-            /*find += CellUtilities.findCellWithMetaKey(
-              this.notebookPanel,
-              READER_CELL_KEY
-            )[0];*/
             // Search for a cell containing the canvas variables key
             find += CellUtilities.findCellWithMetaKey(
               this.notebookPanel,
@@ -920,11 +916,9 @@ export class LeftSideBarWidget extends Widget {
     skip: boolean = false
   ): Promise<number> {
     // Check if required modules are imported in notebook
-    let cmd =
-      "#These imports are required for vcdat. To avoid issues, do not delete or modify.";
+    let cmd = "#These imports are added for vcdat.";
 
     if (skip) {
-      cmd = "#These imports are needed for vcdat.";
       // Check if necessary modules are loaded
       this.usingKernel = true;
       const output: string = await NotebookUtilities.sendSimpleKernelRequest(
@@ -935,7 +929,11 @@ export class LeftSideBarWidget extends Widget {
 
       // Create import string based on missing dependencies
       const missingModules: string[] = eval(output);
-      cmd += this.buildImportCommand(missingModules, false);
+      if (missingModules.length > 0) {
+        cmd += this.buildImportCommand(missingModules, false);
+      } else {
+        return index;
+      }
     } else {
       cmd += this.buildImportCommand(eval(`[${REQUIRED_MODULES}]`), false);
     }

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -114,6 +114,9 @@ export class LeftSideBarWidget extends Widget {
           plotExistTrue={() => {
             this.plotExists = true;
           }}
+          syncNotebook={() => {
+            return this.state == NOTEBOOK_STATE.ActiveNotebook;
+          }}
           getFileVariables={this.getFileVariables}
           getDataVarList={() => {
             return this.dataReaderList;
@@ -533,8 +536,6 @@ export class LeftSideBarWidget extends Widget {
       currentIdx = this.notebookPanel.content.model.cells.length - 1;
       await this.injectCanvasCode(currentIdx, 1);
     }
-
-    this.state = NOTEBOOK_STATE.VCS_Ready;
 
     // Update the selected graphics method, variable list, templates and loaded variables
     await this.refreshGraphicsList();


### PR DESCRIPTION
This update is an attempt to resolve issue #84, it allows vcdat to recognize variables, inject and plot etc. in a notebook that doesn't have meta data. For non-metadata notebooks, the code 'vcs.init()' is run and if no exception occurs, it assumes that vcs functionality can run in the notebook.