### PR TITLE
Contains minor updates and bug fixes

### DIFF
--- a/src/PythonCommands.ts
+++ b/src/PythonCommands.ts
@@ -177,7 +177,7 @@ def check_for_exported_file():\n\
 		time.sleep(1)\n\
 		counter +=1\n\
 		if counter == 15:\n\
-			raise Exception("Exporting plot timed out.")\n\
+			return False\n\
 	return True\n\
 ${OUTPUT_RESULT_NAME}=check_for_exported_file()\n`;
 }

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -35,6 +35,16 @@ export default class Utilities {
   }
 
   /**
+   * Will return the extension of a filename/filepath or empty string.
+   * Example: test.nc => "nc", "test.sdf.tes.nc43534" => "nc43534", test. => "" , test => ""
+   * @param filename The filename/path to remove extension from
+   */
+  public static getExtension(filename: string): string {
+    const match: string[] = filename.match(/\.[^/.]*$/);
+    return match ? match[0].substring(1) : "";
+  }
+
+  /**
    * Will return a string of the path with it's filename removed.
    * Example: folder/dir/test.nc => folder/dir/, test.sdf.tes.nc43534 => /
    * @param path The filename/path to remove extension from

--- a/src/components/ExportPlotModal.tsx
+++ b/src/components/ExportPlotModal.tsx
@@ -20,6 +20,7 @@ import CodeInjector from "../CodeInjector";
 import NotebookUtilities from "../NotebookUtilities";
 import { EXPORT_FORMATS, IMAGE_UNITS } from "../constants";
 import { checkForExportedFileCommand } from "../PythonCommands";
+import Utilities from "../Utilities";
 
 interface IExportPlotModalProps {
   isOpen: boolean;
@@ -128,7 +129,8 @@ export default class ExportPlotModal extends React.Component<
   }
 
   public async save() {
-    const plotName = this.state.plotName;
+    let plotName = this.state.plotName;
+
     if (!plotName) {
       this.setState({ validateExportName: true });
       return;
@@ -143,7 +145,16 @@ export default class ExportPlotModal extends React.Component<
     this.setState({ validateFileFormat: false });
 
     this.props.toggle();
-    this.props.setPlotInfo(this.state.plotName, this.state.plotFileFormat);
+
+    // Remove extension if user typed it in and it matches current format
+    if (Utilities.getExtension(plotName) === fileFormat) {
+      plotName = Utilities.removeExtension(plotName);
+      await this.setState({
+        plotName
+      });
+    }
+
+    this.props.setPlotInfo(plotName, fileFormat);
     this.props.exportAlerts();
     await this.props.codeInjector.exportPlot(
       fileFormat,
@@ -160,9 +171,10 @@ export default class ExportPlotModal extends React.Component<
         checkForExportedFileCommand(plotFileName)
       );
       if (result === "True") {
-        this.props.dismissSavePlotSpinnerAlert();
         this.props.showExportSuccessAlert();
       }
+
+      this.props.dismissSavePlotSpinnerAlert();
     } catch (error) {
       console.error("error with checking file:", error);
     }
@@ -198,7 +210,7 @@ export default class ExportPlotModal extends React.Component<
   public render(): JSX.Element {
     return (
       <Modal isOpen={this.props.isOpen} toggle={this.toggleModal}>
-        <ModalHeader toggle={this.toggleModal}>Save Plot</ModalHeader>
+        <ModalHeader toggle={this.toggleModal}>Export Plot</ModalHeader>
         <ModalBody className={/*@tag<export-modal>*/ "export-modal-vcdat"}>
           <Label>Name:</Label>
           <Input

--- a/src/components/GraphicsMenu.tsx
+++ b/src/components/GraphicsMenu.tsx
@@ -344,7 +344,7 @@ export default class GraphicsMenu extends React.Component<
 
   private handleNameInput(event: React.ChangeEvent<HTMLInputElement>): void {
     // Regex filter for unallowed name characters
-    const forbidden: RegExp = /^[^a-z_]|[^a-z0-9]+/i;
+    const forbidden: RegExp = /^[^_a-z]|[^_a-z0-9]+/i;
     const invalid: boolean = forbidden.test(event.target.value);
     this.setState({ nameValue: event.target.value, invalidName: invalid });
   }


### PR DESCRIPTION
- Fixed a bug that occurs if user enters the extension when exporting their plot. For example, if they enter 'test.png' and export as png, the plot will be saved, but the saving spinner continues to run and it shows a name as 'test.png.png' (but it's correctly saved as 'test.png'). 
- Updated the graphics copy function, so that it allows underscores in the input names.
Before: my_gm = invalid!, after: my_gm = valid

I can merge now, or I can add more fixes to this branch as they come up and merge for next update.