### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,9 +143,4 @@ workflows:
   jupyter_vcdat:
     jobs:
       #- linux_jupyter_vcdat
-      - publish:
-          requires:
-            - linux_jupyter_vcdat
-          filters:
-            branches:
-              only: master
+      - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ aliases:
     environment:
       CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
     command: |
+      export REPO_DIR=`pwd`
       export PKG_NAME=jupyter-vcdat
       export LABEL=nightly
       export USER=cdat
@@ -85,8 +86,8 @@ aliases:
       git clone https://github.com/cdat/conda-recipes
       cd conda-recipes
       export CONDA_RECIPES_REPO=`pwd`
-      ln -s $CIRCLE_WORKING_DIRECTORY .
-      cd $CIRCLE_WORKING_DIRECTORY
+      ln -s $REPO_DIR .
+      cd $REPO_DIR
       python $CONDA_RECIPES_REPO/prep_for_build.py -l $VCDAT_VERSION -b ${CIRCLE_BRANCH}
       conda build $CHANNELS recipe
       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
@@ -94,7 +95,6 @@ aliases:
   - &npm_publish
     name: npm_publish
     command: |
-      echo `ls $CIRCLE_WORKING_DIRECTORY`
       export CDAT_ANONYMOUS_LOG=False
       npm install
       npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -154,10 +154,5 @@ workflows:
   version: 2
   jupyter_vcdat:
     jobs:
-      - linux_jupyter_vcdat
-      - publish:
-          requires:
-            - linux_jupyter_vcdat
-          filters:
-            branches:
-              only: master
+      #- linux_jupyter_vcdat
+      - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ aliases:
         echo "Version of $LOCAL_VERSION in the package.json looks good! NPM publish should work!"
       else
         echo "Version $LOCAL_VERSION in package.json is older than npm version of $NPM_VERSION"
-        echo `You should update version "$LOCAL_VERSION" in package.json to a version greater than $NPM_VERSION`
+        echo "You should update version $LOCAL_VERSION in package.json to a version greater than $NPM_VERSION"
         exit 1
       fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ aliases:
       npm install
       jupyter lab build
       jupyter-labextension install .
+      echo "Installed jupyter-vdat version $LOCAL_VCDAT_VERSION"
       echo "XXX npm list"
       npm list
       git status
@@ -153,5 +154,10 @@ workflows:
   version: 2
   jupyter_vcdat:
     jobs:
-      #- linux_jupyter_vcdat
-      - publish
+      - linux_jupyter_vcdat
+      - publish:
+          requires:
+            - linux_jupyter_vcdat
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ aliases:
       if version_gt $LOCAL_VERSION $NPM_VERSION; then
         echo "Version of $LOCAL_VERSION in the package.json looks good! NPM publish should work!"
       else
-        echo "Version $LOCAL_VERSION in package.json is older than npm version of $NPM_VERSION"
+        echo "Version $LOCAL_VERSION in package.json is not newer than npm version of $NPM_VERSION and will cause NPM publish to fail."
         echo "You should update version $LOCAL_VERSION in package.json to a version greater than $NPM_VERSION"
         exit 1
       fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,23 +11,21 @@ aliases:
       npm install
       jupyter lab build
       jupyter-labextension install .
-      echo "Installed jupyter-vdat version $LOCAL_VCDAT_VERSION"
-      echo "XXX npm list"
-      npm list
-      git status
-  
+      echo "Installed jupyter-vcdat version $LOCAL_VCDAT_VERSION successfully."
+
   - &check_vcdat_versions
     name: check_npm_version
     command: |
-      export LOCAL_VCDAT_VERSION=`node -pe "require('./package.json').version"`
-      export NPM_VCDAT_VERSION=`npm view jupyter-vcdat@nightly version`
+      LOCAL_VCDAT_VERSION=`node -pe "require('./package.json').version"`
+      NPM_VCDAT_VERSION=`npm view jupyter-vcdat@nightly version`
+      echo "export LOCAL_VCDAT_VERSION=$LOCAL_VCDAT_VERSION" >> $BASH_ENV
+      echo "export NPM_VCDAT_VERSION=$NPM_VCDAT_VERSION" >> $BASH_ENV
       function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
       if version_gt $LOCAL_VCDAT_VERSION $NPM_VCDAT_VERSION; then
-        echo "Version of $LOCAL_VCDAT_VERSION in the package.json looks good!"
+        echo "Version of $LOCAL_VCDAT_VERSION in the package.json looks good."
       else
         echo "Version $LOCAL_VCDAT_VERSION in package.json is not newer than npm version of $NPM_VCDAT_VERSION and will cause Publish job to fail."
         echo "You should update version $LOCAL_VCDAT_VERSION in package.json to a version greater than $NPM_VCDAT_VERSION"
-        exit 1
       fi
 
   - &run_jupyter_vcdat
@@ -132,8 +130,8 @@ jobs:
       WORKDIR: "/tmp/jp-vcdat"
     steps:
       - checkout
-      - run: *check_vcdat_versions
       - run: echo 'export PATH=$WORKDIR/miniconda/bin:$PATH' >> $BASH_ENV
+      - run: *check_vcdat_versions
       - run: *setup_jupyter_vcdat
       - run: *run_jupyter_vcdat
       - run: sleep 15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,10 +153,5 @@ workflows:
   version: 2
   jupyter_vcdat:
     jobs:
-      - linux_jupyter_vcdat
-      - publish:
-          requires:
-            - linux_jupyter_vcdat
-          filters:
-            branches:
-              only: master
+      #- linux_jupyter_vcdat
+      - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,16 +77,27 @@ aliases:
       conda build $CHANNELS recipe
       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
 
+  - &check_npm_version
+    name: check_npm_version
+    command: |
+      function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+      LOCAL_VERSION=`node -pe "require('./package.json').version"`
+      NPM_VERSION=`npm view jupyter-vcdat@nightly version`
+      if version_gt $NPM_VERSION $LOCAL_VERSION; then
+        echo "$NPM_VERSION is greater than $LOCAL_VERSION!"
+        echo "You should update 'version' in package.json to version greater than $NPM_VERSION"
+        exit 1
+      fi
+
   - &npm_publish
     name: npm_publish
     command: |
-      echo `ls CIRCLE_WORKING_DIRECTORY`
+      echo `ls $CIRCLE_WORKING_DIRECTORY`
       export CDAT_ANONYMOUS_LOG=False
       npm install
       npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-      git config user.name $CIRCLE_USERNAME
-      npm version patch --verbose -m "Auto-incremented to version $s"
-      git push
+      #git config user.name $CIRCLE_USERNAME
+      #npm version patch --verbose -m "Auto-incremented to version $s"
       npm publish --dry-run --tag nightly
 
   - &docker_publish
@@ -110,9 +121,9 @@ jobs:
     steps:
       - checkout
       - run: *npm_publish
-      #- setup_remote_docker
-      #- run: *docker_publish
-      #- run: *conda_upload
+      - setup_remote_docker
+      - run: *docker_publish
+      - run: *conda_upload
 
   linux_jupyter_vcdat:
     docker:
@@ -123,6 +134,7 @@ jobs:
       - checkout
       - run: echo 'export PATH=$WORKDIR/miniconda/bin:$PATH' >> $BASH_ENV
       - run: *setup_jupyter_vcdat
+      - run: *check_npm_version
       - run: *run_jupyter_vcdat
       - run: sleep 15
       - run: *run_tests_with_chrome
@@ -142,5 +154,10 @@ workflows:
   version: 2
   jupyter_vcdat:
     jobs:
-      #- linux_jupyter_vcdat
-      - publish
+      - linux_jupyter_vcdat
+      - publish:
+          requires:
+            - linux_jupyter_vcdat
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,17 +15,17 @@ aliases:
       npm list
       git status
 
-    - &check_npm_version
-    name: check_npm_version
-    command: |
-      function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
-      LOCAL_VERSION=`node -pe "require('./package.json').version"`
-      NPM_VERSION=`npm view jupyter-vcdat@nightly version`
-      if version_gt $NPM_VERSION $LOCAL_VERSION; then
-        echo "$NPM_VERSION is greater than $LOCAL_VERSION!"
-        echo "You should update 'version' in package.json to version greater than $NPM_VERSION"
-        exit 1
-      fi
+  - &check_npm_version
+  name: check_npm_version
+  command: |
+    function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+    LOCAL_VERSION=`node -pe "require('./package.json').version"`
+    NPM_VERSION=`npm view jupyter-vcdat@nightly version`
+    if version_gt $NPM_VERSION $LOCAL_VERSION; then
+      echo "Current package.json version is $LOCAL_VERSION but npm has newer version of $NPM_VERSION!"
+      echo `You should update version "$LOCAL_VERSION" in package.json to a version greater than $NPM_VERSION`
+      exit 1
+    fi
 
   - &run_jupyter_vcdat
     name: run_jupyter_vcdat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ aliases:
     environment:
       CHANNELS: "-c cdat/label/nightly -c conda-forge -c cdat"
     command: |
-      export REPO_DIR=`pwd`
       export PKG_NAME=jupyter-vcdat
       export LABEL=nightly
       export USER=cdat
@@ -72,8 +71,8 @@ aliases:
       git clone https://github.com/cdat/conda-recipes
       cd conda-recipes
       export CONDA_RECIPES_REPO=`pwd`
-      ln -s $REPO_DIR .
-      cd $REPO_DIR
+      ln -s $CIRCLE_WORKING_DIRECTORY .
+      cd $CIRCLE_WORKING_DIRECTORY
       python $CONDA_RECIPES_REPO/prep_for_build.py -l $VCDAT_VERSION -b ${CIRCLE_BRANCH}
       conda build $CHANNELS recipe
       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
@@ -81,15 +80,14 @@ aliases:
   - &npm_publish
     name: npm_publish
     command: |
-      echo `ls $CONDA_WORKING_DIRECTORY`
-      echo `ls $HOME`
+      echo `ls CIRCLE_WORKING_DIRECTORY`
       export CDAT_ANONYMOUS_LOG=False
       npm install
       npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
       git config user.name $CIRCLE_USERNAME
       npm version patch --verbose -m "Auto-incremented to version $s"
-      npm pack
-      #npm publish --tag nightly
+      git push
+      npm publish --dry-run --tag nightly
 
   - &docker_publish
     name: docker_publish
@@ -111,10 +109,10 @@ jobs:
       VCDAT_VERSION: "2.1.7"
     steps:
       - checkout
+      - run: *npm_publish
       #- setup_remote_docker
       #- run: *docker_publish
       #- run: *conda_upload
-      - run: *npm_publish
 
   linux_jupyter_vcdat:
     docker:
@@ -145,4 +143,9 @@ workflows:
   jupyter_vcdat:
     jobs:
       #- linux_jupyter_vcdat
-      - publish
+      - publish:
+          requires:
+            - linux_jupyter_vcdat
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ aliases:
       npm install
       jupyter lab build
       jupyter-labextension install .
-      echo "Installed jupyter-vcdat version $LOCAL_VCDAT_VERSION successfully."
+      echo -e "\nInstalled jupyter-vcdat version $LOCAL_VCDAT_VERSION successfully."
 
   - &check_vcdat_versions
     name: check_npm_version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,18 @@ aliases:
       npm list
       git status
 
+    - &check_npm_version
+    name: check_npm_version
+    command: |
+      function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+      LOCAL_VERSION=`node -pe "require('./package.json').version"`
+      NPM_VERSION=`npm view jupyter-vcdat@nightly version`
+      if version_gt $NPM_VERSION $LOCAL_VERSION; then
+        echo "$NPM_VERSION is greater than $LOCAL_VERSION!"
+        echo "You should update 'version' in package.json to version greater than $NPM_VERSION"
+        exit 1
+      fi
+
   - &run_jupyter_vcdat
     name: run_jupyter_vcdat
     command: |
@@ -77,18 +89,6 @@ aliases:
       conda build $CHANNELS recipe
       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
 
-  - &check_npm_version
-    name: check_npm_version
-    command: |
-      function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
-      LOCAL_VERSION=`node -pe "require('./package.json').version"`
-      NPM_VERSION=`npm view jupyter-vcdat@nightly version`
-      if version_gt $NPM_VERSION $LOCAL_VERSION; then
-        echo "$NPM_VERSION is greater than $LOCAL_VERSION!"
-        echo "You should update 'version' in package.json to version greater than $NPM_VERSION"
-        exit 1
-      fi
-
   - &npm_publish
     name: npm_publish
     command: |
@@ -96,9 +96,7 @@ aliases:
       export CDAT_ANONYMOUS_LOG=False
       npm install
       npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-      #git config user.name $CIRCLE_USERNAME
-      #npm version patch --verbose -m "Auto-incremented to version $s"
-      npm publish --dry-run --tag nightly
+      npm publish --tag nightly
 
   - &docker_publish
     name: docker_publish
@@ -132,9 +130,9 @@ jobs:
       WORKDIR: "/tmp/jp-vcdat"
     steps:
       - checkout
+      - run: *check_npm_version
       - run: echo 'export PATH=$WORKDIR/miniconda/bin:$PATH' >> $BASH_ENV
       - run: *setup_jupyter_vcdat
-      - run: *check_npm_version
       - run: *run_jupyter_vcdat
       - run: sleep 15
       - run: *run_tests_with_chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,18 +14,18 @@ aliases:
       echo "XXX npm list"
       npm list
       git status
-
-  - &check_npm_version
+  
+  - &check_vcdat_versions
     name: check_npm_version
     command: |
+      export LOCAL_VCDAT_VERSION=`node -pe "require('./package.json').version"`
+      export NPM_VCDAT_VERSION=`npm view jupyter-vcdat@nightly version`
       function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
-      LOCAL_VERSION=`node -pe "require('./package.json').version"`
-      NPM_VERSION=`npm view jupyter-vcdat@nightly version`
-      if version_gt $LOCAL_VERSION $NPM_VERSION; then
-        echo "Version of $LOCAL_VERSION in the package.json looks good! NPM publish should work!"
+      if version_gt $LOCAL_VCDAT_VERSION $NPM_VCDAT_VERSION; then
+        echo "Version of $LOCAL_VCDAT_VERSION in the package.json looks good!"
       else
-        echo "Version $LOCAL_VERSION in package.json is not newer than npm version of $NPM_VERSION and will cause NPM publish to fail."
-        echo "You should update version $LOCAL_VERSION in package.json to a version greater than $NPM_VERSION"
+        echo "Version $LOCAL_VCDAT_VERSION in package.json is not newer than npm version of $NPM_VCDAT_VERSION and will cause Publish job to fail."
+        echo "You should update version $LOCAL_VCDAT_VERSION in package.json to a version greater than $NPM_VCDAT_VERSION"
         exit 1
       fi
 
@@ -88,9 +88,9 @@ aliases:
       export CONDA_RECIPES_REPO=`pwd`
       ln -s $REPO_DIR .
       cd $REPO_DIR
-      python $CONDA_RECIPES_REPO/prep_for_build.py -l $VCDAT_VERSION -b ${CIRCLE_BRANCH}
+      python $CONDA_RECIPES_REPO/prep_for_build.py -l $LOCAL_VCDAT_VERSION -b ${CIRCLE_BRANCH}
       conda build $CHANNELS recipe
-      anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
+      anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$LOCAL_VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
 
   - &npm_publish
     name: npm_publish
@@ -107,8 +107,8 @@ aliases:
       echo "$DOCKER_TOKEN" | docker login --username downie4 --password-stdin
       echo "$DOCKER_TOKEN2" | docker login --username downie4 --password-stdin $DOCKER_IMAGE_SOURCE
       docker build --no-cache --tag=cdat/vcdat:nightly .
-      docker image tag cdat/vcdat:nightly cdat/vcdat:$VCDAT_VERSION
-      docker push cdat/vcdat:$VCDAT_VERSION
+      docker image tag cdat/vcdat:nightly cdat/vcdat:$LOCAL_VCDAT_VERSION
+      docker push cdat/vcdat:$LOCAL_VCDAT_VERSION
       docker push cdat/vcdat:nightly
       docker logout
 
@@ -116,10 +116,9 @@ jobs:
   publish:
     docker:
       - image: cdat/vcdat_circleci:nightly
-    environment:
-      VCDAT_VERSION: "2.1.7"
     steps:
       - checkout
+      - run: *check_vcdat_versions
       - run: *npm_publish
       - setup_remote_docker
       - run: *docker_publish
@@ -132,7 +131,7 @@ jobs:
       WORKDIR: "/tmp/jp-vcdat"
     steps:
       - checkout
-      - run: *check_npm_version
+      - run: *check_vcdat_versions
       - run: echo 'export PATH=$WORKDIR/miniconda/bin:$PATH' >> $BASH_ENV
       - run: *setup_jupyter_vcdat
       - run: *run_jupyter_vcdat
@@ -154,5 +153,10 @@ workflows:
   version: 2
   jupyter_vcdat:
     jobs:
-      #- linux_jupyter_vcdat
-      - publish
+      - linux_jupyter_vcdat
+      - publish:
+          requires:
+            - linux_jupyter_vcdat
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ aliases:
       export CONDA_RECIPES_REPO=`pwd`
       ln -s $REPO_DIR .
       cd $REPO_DIR
-      echo $REPO_DIR, $CONDA_RECIPES_REPO, $CONDA_BUILD_PATH, ${CIRCLE_BRANCH}
       python $CONDA_RECIPES_REPO/prep_for_build.py -l $VCDAT_VERSION -b ${CIRCLE_BRANCH}
       conda build $CHANNELS recipe
       anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/noarch/$PKG_NAME-$VCDAT_VERSION.`date +%Y*`0.tar.bz2 --force
@@ -82,12 +81,15 @@ aliases:
   - &npm_publish
     name: npm_publish
     command: |
+      echo `ls $CONDA_WORKING_DIRECTORY`
+      echo `ls $HOME`
       export CDAT_ANONYMOUS_LOG=False
       npm install
       npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
       git config user.name $CIRCLE_USERNAME
-      npm version patch -m "Auto-incremented to version $s"
-      npm publish --tag nightly
+      npm version patch --verbose -m "Auto-incremented to version $s"
+      npm pack
+      #npm publish --tag nightly
 
   - &docker_publish
     name: docker_publish
@@ -109,9 +111,9 @@ jobs:
       VCDAT_VERSION: "2.1.7"
     steps:
       - checkout
-      - setup_remote_docker
-      - run: *docker_publish
-      - run: *conda_upload
+      #- setup_remote_docker
+      #- run: *docker_publish
+      #- run: *conda_upload
       - run: *npm_publish
 
   linux_jupyter_vcdat:
@@ -142,10 +144,5 @@ workflows:
   version: 2
   jupyter_vcdat:
     jobs:
-      - linux_jupyter_vcdat
-      - publish:
-          requires:
-            - linux_jupyter_vcdat
-          filters:
-            branches:
-              only: master
+      #- linux_jupyter_vcdat
+      - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,18 @@ aliases:
       git status
 
   - &check_npm_version
-  name: check_npm_version
-  command: |
-    function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
-    LOCAL_VERSION=`node -pe "require('./package.json').version"`
-    NPM_VERSION=`npm view jupyter-vcdat@nightly version`
-    if version_gt $NPM_VERSION $LOCAL_VERSION; then
-      echo "Current package.json version is $LOCAL_VERSION but npm has newer version of $NPM_VERSION!"
-      echo `You should update version "$LOCAL_VERSION" in package.json to a version greater than $NPM_VERSION`
-      exit 1
-    fi
+    name: check_npm_version
+    command: |
+      function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+      LOCAL_VERSION=`node -pe "require('./package.json').version"`
+      NPM_VERSION=`npm view jupyter-vcdat@nightly version`
+      if version_gt $LOCAL_VERSION $NPM_VERSION; then
+        echo "Version of $LOCAL_VERSION in the package.json looks good! NPM publish should work!"
+      else
+        echo "Version $LOCAL_VERSION in package.json is older than npm version of $NPM_VERSION"
+        echo `You should update version "$LOCAL_VERSION" in package.json to a version greater than $NPM_VERSION`
+        exit 1
+      fi
 
   - &run_jupyter_vcdat
     name: run_jupyter_vcdat

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/
 node_modules/
 *.egg-info/
 .ipynb_checkpoints
+sample_data/
 frontend/
 .DS_Store
 .vscode/

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -12,4 +12,4 @@ ENV CDAT_ANONYMOUS_LOG false
 # extension
 # Our extension needs to be built from npm repo otherwise jupyter-lab
 # tries to write into image and shifter does not let us do this.
-RUN jupyter labextension install jupyter-vcdat && conda update -c cdat/label/nightly -c conda-forge vcs cdms2 cdutil genutil libcdms
+RUN jupyter labextension install jupyter-vcdat@nightly && conda update -c cdat/label/nightly -c conda-forge vcs cdms2 cdutil genutil libcdms

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-vcdat",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-vcdat",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-vcdat",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "./precommit_checks.sh && lint-staged"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-vcdat",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "A vCDAT extension for JupyterLab.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-vcdat",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "A vCDAT extension for JupyterLab.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-vcdat",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "A vCDAT extension for JupyterLab.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
I changed the config publish script so that the npm version will not be automatically updated. Instead circleci will perform a test to check whether the version in package.json has been updated to be greater than the version in npm. If the version hasn't been updated (which means the npm publish step would fail), then the test will fail and that will ensure that any PRs that are pushed must have an updated version. This test is performed before any other, so that the circleci test should fail early, before losing time with other tests.