### PR TITLE
Disable sliders

### DIFF
--- a/tasksfile.ts
+++ b/tasksfile.ts
@@ -55,6 +55,12 @@ const TESTS: { [name: string]: string[] } = {
   test_file_browser_locators: [
     "TestFileBrowserLocators",
     "test_double_click_on_a_file"
+  ],
+  test_export_html: [
+    "TestExportHTML",
+    "test_export_plot_html_via_button",
+    "test_export_plot_html_via_nbconvert",
+    "test_export_plot_html_via_nbconvert_execute"
   ]
 };
 
@@ -521,7 +527,7 @@ async function installTestTools(): Promise<void> {
 
       console.log("Installing...");
       await shell(
-        "conda install -c cdat/label/v81 testsrunner cdat_info <<< 'yes' && \
+        "conda install -c cdat/label/v82 testsrunner cdat_info <<< 'yes' && \
       pip install selenium && pip install pyvirtualdisplay"
       );
     } else {

--- a/tests/PageObjects/NoteBookPage.py
+++ b/tests/PageObjects/NoteBookPage.py
@@ -56,3 +56,13 @@ class NoteBookPage(MainPage):
             self.move_to_click(ok_element)
         except NoSuchElementException:
             print("No 'Close without saving?' pop up")
+
+    def click_on_export_to_HTML(self):
+        print('...click_on_export_to_HTML...')
+        self.click_on_top_menu_item('File')
+        locator = "//ul[@class='p-Menu-content']/li[@data-type='submenu']/div[contains(text(),'Export Notebook')]"
+        elem = self.find_element_by_xpath(locator, "Export Menu")
+        self.move_to_click(elem)
+        locator = "//ul[@class='p-Menu-content']/li[@data-type='command']/div[contains(text(),'Export Notebook to HTML')]"
+        elem = self.find_element_by_xpath(locator, "Export HTML")
+        self.move_to_click(elem)

--- a/tests/TestUtils/BaseTestCase.py
+++ b/tests/TestUtils/BaseTestCase.py
@@ -66,6 +66,19 @@ class BaseTestCase(unittest.TestCase):
         chrome_options.add_argument(mode)
         chrome_options.add_argument("--no-sandbox")
         chrome_options.add_argument("window-size=1200x600")
+        # Set up download directory
+        # # https://stackoverflow.com/questions/18437816/how-to-find-chrome-download-path-in-java
+        # # http://makeseleniumeasy.com/2018/08/25/how-to-change-default-download-directory-for-chrome-browser-in-selenium-webdriver/
+        prefs = {
+            "download": {
+                "default_directory": os.getcwd()
+            }
+        }
+        chrome_options.add_experimental_option("prefs", prefs)
+        # https://stackoverflow.com/questions/47019839/python-selenium-with-chrome-how-to-download-to-a-specified-folder-with-specifie
+        #chrome_options.add_argument("download.default_directory={}".format(os.getcwd()))
+        # prefs = {"download.default_directory": os.getcwd()}
+        #chrome_options.add_experimental_option("prefs", prefs)
         self.driver = webdriver.Chrome(executable_path=os.getenv("BROWSER_DRIVER", "/usr/local/bin/chromedriver"),
                                        chrome_options=chrome_options,
                                        service_args=['--verbose', '--log-path=/tmp/chromedriver.log'])

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -1,0 +1,98 @@
+import os
+import sys
+
+this_dir = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(this_dir, 'TestUtils'))
+sys.path.append(os.path.join(this_dir, 'PageObjects'))
+
+from BaseTestCaseWithNoteBook import BaseTestCaseWithNoteBook
+from VcdatPanel import VcdatPanel
+
+
+def debug_print(s):
+    DEBUG = True
+    if DEBUG:
+        print(s)
+
+
+def assert_image_tag_present(html_file):
+    debug_print('Assert image tag is present')
+    image_tag_present = False
+    with open(html_file, 'r') as f:
+        for line in f:
+            # If SLIDERS_ENABLED is False, then this tag appears in the HTML.
+            # If SLIDERS_ENABLED is True, then this tag does not appear in the HTML.
+            # However, the image itself still appears.
+            if '<img' in line:
+                image_tag_present = True
+    assert image_tag_present
+
+
+class TestExportHTML(BaseTestCaseWithNoteBook):
+    """
+    This class has methods to test exporting to HTML.
+    """
+
+    def setUp(self):
+        """
+        Open, edit, and save the notebook before each test.
+        """
+        super(TestExportHTML, self).setUp()
+        notebook = self.notebooks[0]
+        test_file = "clt.nc"
+        notebook.click_on_folder_tab()
+        notebook.click_on_vcdat_icon()
+        vcdat_panel = VcdatPanel(self.driver, None)
+        file_browser = vcdat_panel.click_on_load_variables_by_file()
+        load_variable_popup = file_browser.double_click_on_a_file(test_file)
+        load_variable_popup.click_on_variable('v')
+        load_variable_popup.click_on_load()
+        vcdat_panel.click_on_plot()
+        notebook.save_current_notebook()
+        self.notebook_name = notebook.notebook_name
+
+    def execute_notebook_via_web(self):
+        """
+        Execute the notebook via web interface.
+        """
+        debug_print('Execute the notebook via web interface.')
+        self.notebooks[0].click_on_running_tab()
+
+    def check_image_tag_in_html(self):
+        """
+        Check that the HTML file contains an image tag.
+        """
+        debug_print('Check that HTML contains image.')
+        html_path = self.notebook_name.replace('.ipynb', '.html')
+        # TODO: Is checking the image tag exists good enough?
+        #  Or should we open the html file using Selenium?
+        assert_image_tag_present(html_path)
+
+    def test_export_plot_html_via_button(self):
+        """
+        Test that running a notebook and then exporting to HTML via the "Export Notebook as" button displays the plot in the HTML.
+        """
+        self.execute_notebook_via_web()
+        # File > Export as > Export as HTML
+        debug_print('Click button to download as HTML.')
+        self.notebooks[0].click_on_export_to_HTML()
+        self.check_image_tag_in_html()
+
+    def test_export_plot_html_via_nbconvert(self):
+        """
+        Test that running a notebook and then exporting to HTML via `jupyter nbconvert --to html` displays the plot in the HTML.
+        """
+        self.execute_notebook_via_web()
+        debug_print('Convert the notebook.')
+        convert_command = 'jupyter nbconvert --to html {}'.format(self.notebook_name)
+        assert os.system(convert_command) == 0
+        self.check_image_tag_in_html()
+
+    def test_export_plot_html_via_nbconvert_execute(self):
+        """
+        Test that running `jupyter nbconvert --execute --to html` displays the plot in the HTML.
+        """
+        debug_print('Execute and convert the notebook in one step.')
+        command = 'jupyter nbconvert --to html --execute {}'.format(self.notebook_name)
+        assert os.system(command) == 0
+        self.check_image_tag_in_html()


### PR DESCRIPTION
Testing for disabling sliders (https://github.com/CDAT/vcs/pull/428)

To run:
```
conda create -n <env_name> -c cdat/label/nightly -c conda-forge jupyterlab jupyterhub "python=3.7" nodejs vcs pip
python -m pip install sidecar
conda activate <env_name>
jupyter labextension install @jupyter-widgets/jupyterlab-manager
jupyter labextension install @jupyter-widgets/jupyterlab-sidecar
jupyter labextension install jupyterlab-tutorial-extension
jupyter labextension install @jupyterlab/hub-extension
npm install
jupyter lab build
conda install -c conda-forge ipywidgets

# To install vcs changes:
cd ../vcs; python setup.py install; cd -

To run tests:
# Close out of other Jupyter Lab instances
jupyter labextension install .
jupyter lab
npx task test -c test_export_plot_html_via_button &> out.txt
```